### PR TITLE
Add SimulationSystem for internal scenario planning

### DIFF
--- a/src/UltraWorldAI/GoalSystem.cs
+++ b/src/UltraWorldAI/GoalSystem.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI
+{
+    public class GoalSystem
+    {
+        public List<Goal> ActiveGoals { get; } = new();
+
+        public void AddGoal(string description, float urgency)
+        {
+            ActiveGoals.Add(new Goal { Description = description, Urgency = urgency });
+        }
+
+        public void RemoveGoal(Goal goal)
+        {
+            ActiveGoals.Remove(goal);
+        }
+    }
+
+    public class Goal
+    {
+        public string Description { get; set; } = string.Empty;
+        public float Urgency { get; set; }
+    }
+}

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -16,6 +16,8 @@ namespace UltraWorldAI
         public SelfNarrativeSystem SelfNarrative { get; private set; }
         public SemanticMemory Knowledge { get; private set; }
         public IdeaNetwork IdeaNet { get; private set; }
+        public GoalSystem Goals { get; private set; }
+        public SimulationSystem Simulation { get; private set; }
 
         public Mind(Person person)
         {
@@ -31,6 +33,8 @@ namespace UltraWorldAI
             Knowledge = new SemanticMemory();
             Narrative = new NarrativeEngine(person);
             IdeaNet = new IdeaNetwork();
+            Goals = new GoalSystem();
+            Simulation = new SimulationSystem();
         }
 
         public void Update()
@@ -40,6 +44,8 @@ namespace UltraWorldAI
             Knowledge.DecayFacts();
             Stress.UpdateStressDecay();
             IdeaNet.GenerateNewIdea("conflito", Emotions, Memory, Beliefs);
+            Simulation.Simulate(Emotions, Goals, Memory);
         }
     }
 }
+

--- a/src/UltraWorldAI/SimulationSystem.cs
+++ b/src/UltraWorldAI/SimulationSystem.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI
+{
+    public class SimulationSystem
+    {
+        public List<InternalScenario> ImaginedScenarios { get; private set; }
+        public string LifeNarrative { get; private set; }
+
+        private static readonly Random _random = new Random();
+
+        public SimulationSystem()
+        {
+            ImaginedScenarios = new List<InternalScenario>();
+            LifeNarrative = "Início de uma jornada desconhecida...";
+        }
+
+        public void Simulate(EmotionSystem emotions, GoalSystem goals, MemorySystem memory)
+        {
+            ImaginedScenarios.Clear();
+
+            var primaryGoal = goals.ActiveGoals.OrderByDescending(g => g.Urgency).FirstOrDefault();
+            if (primaryGoal == null) return;
+
+            var imaginedOutcome = GenerateOutcome(primaryGoal, emotions);
+            ImaginedScenarios.Add(imaginedOutcome);
+
+            UpdateLifeNarrative(imaginedOutcome);
+        }
+
+        private InternalScenario GenerateOutcome(Goal goal, EmotionSystem emotions)
+        {
+            var emotion = emotions.GetDominantEmotion();
+            var outcome = new InternalScenario
+            {
+                Goal = goal.Description,
+                ImaginedEmotion = emotion,
+                Outcome = SimulateConsequence(goal.Description, emotion),
+                Confidence = _random.NextDouble() * 0.8 + 0.2
+            };
+
+            return outcome;
+        }
+
+        private string SimulateConsequence(string goal, string emotion)
+        {
+            if (emotion == "fear" && goal.Contains("confrontar"))
+                return "Você se machuca e gera conflito social.";
+            if (emotion == "love" && goal.Contains("cuidar"))
+                return "Você fortalece vínculos e ganha confiança.";
+            if (emotion == "anger")
+                return "Você toma decisões impulsivas e causa problemas.";
+            if (goal.Contains("explorar"))
+                return "Você encontra algo inesperado.";
+            return "Você age, mas o resultado é incerto.";
+        }
+
+        private void UpdateLifeNarrative(InternalScenario scenario)
+        {
+            var entry = $"Pensou em '{scenario.Goal}' com sentimento de '{scenario.ImaginedEmotion}' e visualizou: '{scenario.Outcome}'";
+            LifeNarrative += "\n→ " + entry;
+
+            if (LifeNarrative.Length > 500)
+                LifeNarrative = LifeNarrative[^500..];
+        }
+
+        public List<string> GetRecentSimulations()
+        {
+            return ImaginedScenarios.Select(s =>
+                $"Meta: {s.Goal}, Emoção: {s.ImaginedEmotion}, Consequência: {s.Outcome}, Confiança: {s.Confidence:F2}")
+                .ToList();
+        }
+
+        public string GetLifeNarrative() => LifeNarrative;
+    }
+
+    public class InternalScenario
+    {
+        public string Goal { get; set; } = string.Empty;
+        public string ImaginedEmotion { get; set; } = string.Empty;
+        public string Outcome { get; set; } = string.Empty;
+        public double Confidence { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `GoalSystem` to manage agent goals
- create `SimulationSystem` to imagine consequences and update life narrative
- wire `GoalSystem` and `SimulationSystem` into `Mind`

## Testing
- `dotnet build src/UltraWorldAI/UltraWorldAI.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0f824848323b8322665e4bf79fd