### PR TITLE
Enhance memory retrieval weights

### DIFF
--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -109,12 +109,24 @@ namespace UltraWorldAI
 
         public List<Memory> RetrieveMemories(string keyword, int count = 5)
         {
-            return Memories.Where(m =>
-                                m.Keywords.Any(k => k.Contains(keyword, StringComparison.OrdinalIgnoreCase)) ||
-                                m.Summary.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                            .OrderByDescending(m => m.Intensity)
-                            .Take(count)
-                            .ToList();
+            var now = DateTime.Now;
+            var results = Memories
+                .Where(m => string.IsNullOrWhiteSpace(keyword) ||
+                             m.Keywords.Any(k => k.Contains(keyword, StringComparison.OrdinalIgnoreCase)) ||
+                             m.Summary.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(m =>
+                    (m.Intensity * 0.6f) +
+                    (Math.Abs(m.EmotionalCharge) * 0.3f) +
+                    (float)(1.0 / (1.0 + (now - m.Date).TotalDays)))
+                .Take(count)
+                .ToList();
+
+            foreach (var mem in results)
+            {
+                mem.Intensity = Math.Min(1f, mem.Intensity + 0.05f);
+            }
+
+            return results;
         }
     }
 }

--- a/tests/UltraWorldAI.Tests/MemoryTests.cs
+++ b/tests/UltraWorldAI.Tests/MemoryTests.cs
@@ -10,4 +10,16 @@ public class MemoryTests
         memSys.AddMemory("evento", 0.5f);
         Assert.Single(memSys.Memories);
     }
+
+    [Fact]
+    public void RetrieveMemoriesOrdersByWeight()
+    {
+        var memSys = new MemorySystem();
+        memSys.AddMemory("neutro", 0.3f, 0.1f, new() { "teste" });
+        memSys.AddMemory("emocional", 0.2f, 0.9f, new() { "teste" });
+
+        var result = memSys.RetrieveMemories("teste", 2);
+
+        Assert.Equal("emocional", result[0].Summary);
+    }
 }


### PR DESCRIPTION
## Summary
- improve how memories are ranked when retrieved
- bump memory intensity when a memory is recalled
- verify retrieval order via new unit test

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6840ef832dd883238a0b2b33e41e087a