### PR TITLE
Add Intuition System

### DIFF
--- a/src/UltraWorldAI/IntuitionSystem.cs
+++ b/src/UltraWorldAI/IntuitionSystem.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI
+{
+    public class IntuitionSystem
+    {
+        public List<Insight> Insights { get; } = new();
+
+        public void GenerateInsight(Mind brain)
+        {
+            var seedIdeas = brain.BrainMap.GetAssociatedIdeas(brain.Emotions.GetDominantEmotion());
+            if (seedIdeas.Count == 0)
+                return;
+
+            var theme = seedIdeas[0].Split(' ')[0];
+            var insight = new Insight
+            {
+                Statement = $"Talvez a verdade esteja em {theme}",
+                EmotionBasis = brain.Emotions.GetDominantEmotion(),
+                Confidence = 0.4f + brain.Personality.GetTrait("Curiosity") * 0.6f,
+                Source = "Intuição emocional"
+            };
+
+            brain.Memory.AddMemory($"Insight: {insight.Statement}", insight.Confidence, 0f, new() { "Insight" }, "insight");
+            Insights.Add(insight);
+        }
+
+        public List<Insight> GetCoreBeliefs()
+        {
+            return Insights.Where(i => i.Confidence > 0.6f).ToList();
+        }
+
+        public void ReinforceInsight(string statement, float amount = 0.05f)
+        {
+            var target = Insights.FirstOrDefault(i => i.Statement == statement);
+            if (target != null)
+                target.Confidence = Math.Min(1f, target.Confidence + amount);
+        }
+    }
+
+    public class Insight
+    {
+        public string Statement { get; set; } = string.Empty;
+        public string EmotionBasis { get; set; } = string.Empty;
+        public float Confidence { get; set; }
+        public string Source { get; set; } = string.Empty;
+    }
+}

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -19,6 +19,7 @@ namespace UltraWorldAI
         public IdeaNetwork IdeaNet { get; private set; }
         public ThoughtSystem ThoughtEngine { get; private set; }
         public BrainwireSystem BrainMap { get; private set; }
+        public IntuitionSystem Intuition { get; private set; }
         public GoalSystem Goals { get; private set; }
         public SimulationSystem Simulation { get; private set; }
         public SubpersonalitySystem Subvoices { get; private set; }
@@ -44,6 +45,7 @@ namespace UltraWorldAI
             IdeaNet = new IdeaNetwork();
             ThoughtEngine = new ThoughtSystem();
             BrainMap = new BrainwireSystem();
+            Intuition = new IntuitionSystem();
             Goals = new GoalSystem();
             Simulation = new SimulationSystem();
             Subvoices = new SubpersonalitySystem();
@@ -66,6 +68,7 @@ namespace UltraWorldAI
             ThoughtEngine.GenerateThought(this);
             ThoughtEngine.DecayThoughts();
             BrainMap.Decay();
+            Intuition.GenerateInsight(this);
             InternalNarrative.GenerateReflection(this);
             InternalNarrative.InteractWithSubvoices(Subvoices);
         }

--- a/tests/UltraWorldAI.Tests/IntuitionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/IntuitionSystemTests.cs
@@ -1,0 +1,29 @@
+using UltraWorldAI;
+using Xunit;
+
+public class IntuitionSystemTests
+{
+    [Fact]
+    public void GenerateInsightCreatesEntry()
+    {
+        var person = new Person("Tester");
+        person.Mind.BrainMap.Connect("happiness", "nature", 0.5f);
+        person.Mind.Emotions.SetEmotion("happiness", 0.9f);
+        person.Mind.Intuition.GenerateInsight(person.Mind);
+        Assert.Single(person.Mind.Intuition.Insights);
+        Assert.Contains(person.Mind.Memory.Memories, m => m.Summary.Contains("Insight:"));
+    }
+
+    [Fact]
+    public void ReinforceInsightRaisesConfidence()
+    {
+        var person = new Person("Tester");
+        person.Mind.BrainMap.Connect("fear", "noite", 0.5f);
+        person.Mind.Emotions.SetEmotion("fear", 0.9f);
+        person.Mind.Intuition.GenerateInsight(person.Mind);
+        var statement = person.Mind.Intuition.Insights[0].Statement;
+        person.Mind.Intuition.ReinforceInsight(statement, 0.6f);
+        var core = person.Mind.Intuition.GetCoreBeliefs();
+        Assert.Contains(person.Mind.Intuition.Insights[0], core);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `IntuitionSystem` with insight generation and reinforcement
- integrate intuition into `Mind` lifecycle
- test new system

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6840f20a62e08323b153f62db9f00640