### PR TITLE
Implement contradiction system

### DIFF
--- a/src/UltraWorldAI/ContradictionSystem.cs
+++ b/src/UltraWorldAI/ContradictionSystem.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI
+{
+    public class ContradictionSystem
+    {
+        public List<string> Contradictions { get; } = new();
+        public List<string> SelfSabotageEvents { get; } = new();
+        public float InnerTensionLevel { get; private set; }
+
+        public void EvaluateContradictions(GoalSystem goals, EmotionSystem emotions, SubpersonalitySystem subvoices)
+        {
+            Contradictions.Clear();
+            InnerTensionLevel = 0f;
+
+            var goal = goals.ActiveGoals.OrderByDescending(g => g.Urgency).FirstOrDefault();
+            var dominant = subvoices.GetDominantVoice();
+
+            if (goal != null && dominant != null)
+            {
+                if (goal.Description.Contains("confrontar", StringComparison.OrdinalIgnoreCase)
+                    && dominant.Name == "Filósofo")
+                {
+                    Contradictions.Add("Deseja confrontar, mas sente que deveria refletir.");
+                    InnerTensionLevel += 0.4f;
+                }
+
+                if (goal.Description.Contains("amar", StringComparison.OrdinalIgnoreCase)
+                    && dominant.Name == "Ferido")
+                {
+                    Contradictions.Add("Deseja conexão, mas o trauma impede proximidade.");
+                    InnerTensionLevel += 0.6f;
+                }
+            }
+
+            if (emotions.GetEmotion("love") > 0.6f && emotions.GetEmotion("fear") > 0.6f)
+            {
+                Contradictions.Add("Ama intensamente, mas teme profundamente.");
+                InnerTensionLevel += 0.5f;
+            }
+
+            var topVoices = subvoices.Subpersonalities
+                .OrderByDescending(v => v.CurrentInfluence)
+                .Take(2)
+                .ToList();
+            if (topVoices.Count == 2 &&
+                Math.Abs(topVoices[0].CurrentInfluence - topVoices[1].CurrentInfluence) < 0.1f)
+            {
+                Contradictions.Add("Duas vozes internas lutam pelo controle.");
+                InnerTensionLevel += 0.3f;
+            }
+
+            InnerTensionLevel = Math.Min(1f, InnerTensionLevel);
+        }
+
+        public void TriggerSelfSabotage(Mind brain)
+        {
+            if (InnerTensionLevel > 0.6f)
+            {
+                const string action = "Desistiu de um objetivo importante.";
+                SelfSabotageEvents.Add(action);
+                brain.Goals.ActiveGoals.Clear();
+                brain.Memory.AddMemory(action, 0.5f, -0.5f, new() { "Autossabotagem" }, "self");
+            }
+        }
+
+        public string GetContradictionSummary()
+        {
+            return Contradictions.Any()
+                ? $"⚠️ Contradições: {string.Join("; ", Contradictions)}"
+                : "🟢 Estado psicológico estável.";
+        }
+    }
+}

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -30,6 +30,7 @@ namespace UltraWorldAI
         public RitualSystem Rituals { get; private set; }
         public ExternalSupportSystem ExternalSupport { get; private set; }
         public PhilosophySystem Philosophy { get; private set; }
+        public ContradictionSystem Contradictions { get; private set; }
 
         public Mind(Person person)
         {
@@ -59,6 +60,7 @@ namespace UltraWorldAI
             Rituals = new RitualSystem();
             ExternalSupport = new ExternalSupportSystem();
             Philosophy = new PhilosophySystem();
+            Contradictions = new ContradictionSystem();
         }
 
         public void Update()
@@ -71,6 +73,8 @@ namespace UltraWorldAI
             IdeaNet.GenerateNewIdea("conflito", Emotions, Memory, Beliefs);
             Simulation.Simulate(Emotions, Goals, Memory);
             Subvoices.UpdateInfluences();
+            Contradictions.EvaluateContradictions(Goals, Emotions, Subvoices);
+            Contradictions.TriggerSelfSabotage(this);
             ThoughtEngine.GenerateThought(this);
             ThoughtEngine.DecayThoughts();
             BrainMap.Decay();

--- a/tests/UltraWorldAI.Tests/ContradictionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ContradictionSystemTests.cs
@@ -1,0 +1,43 @@
+using UltraWorldAI;
+using Xunit;
+
+public class ContradictionSystemTests
+{
+    [Fact]
+    public void EvaluateDetectsInternalConflict()
+    {
+        var person = new Person("Tester");
+        person.Mind.Goals.AddGoal("confrontar inimigo", 0.9f);
+        foreach (var sub in person.Mind.Subvoices.Subpersonalities)
+            sub.CurrentInfluence = sub.Name == "Filósofo" ? 0.9f : 0.1f;
+
+        person.Mind.Contradictions.EvaluateContradictions(
+            person.Mind.Goals,
+            person.Mind.Emotions,
+            person.Mind.Subvoices);
+
+        Assert.Contains("Deseja confrontar, mas sente que deveria refletir.",
+            person.Mind.Contradictions.Contradictions);
+    }
+
+    [Fact]
+    public void TriggerSelfSabotageClearsGoals()
+    {
+        var person = new Person("Saboteur");
+        person.Mind.Goals.AddGoal("confrontar adversidade", 0.9f);
+        foreach (var sub in person.Mind.Subvoices.Subpersonalities)
+            sub.CurrentInfluence = sub.Name == "Filósofo" ? 0.9f : 0.1f;
+        person.Mind.Emotions.SetEmotion("love", 0.7f);
+        person.Mind.Emotions.SetEmotion("fear", 0.7f);
+
+        person.Mind.Contradictions.EvaluateContradictions(
+            person.Mind.Goals,
+            person.Mind.Emotions,
+            person.Mind.Subvoices);
+        person.Mind.Contradictions.TriggerSelfSabotage(person.Mind);
+
+        Assert.Empty(person.Mind.Goals.ActiveGoals);
+        Assert.Contains(person.Mind.Memory.Memories,
+            m => m.Summary.Contains("Desistiu de um objetivo importante."));
+    }
+}


### PR DESCRIPTION
## Summary
- add ContradictionSystem to model internal tensions and self-sabotage
- integrate the new system into Mind
- test contradictions and self-sabotage logic

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_684191aa9af88323a2dd5cc4c88146cf