### PR TITLE
Implement DoctrineSystem and integrate into Mind

### DIFF
--- a/src/UltraWorldAI/DoctrineSystem.cs
+++ b/src/UltraWorldAI/DoctrineSystem.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI
+{
+    public class Doctrine
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<string> Tenets { get; set; } = new();
+        public string OriginSymbol { get; set; } = string.Empty;
+    }
+
+    public class DoctrineSystem
+    {
+        public List<Doctrine> Doctrines { get; } = new();
+        public List<string> CoreTruths { get; } = new();
+
+        public void EvolveFromSymbolsAndBeliefs(SymbolicExpressionSystem symbols, BeliefSystem beliefs)
+        {
+            var meaningfulSymbols = symbols.Symbols
+                .TakeLast(3)
+                .Select(s => s.Motif)
+                .ToList();
+
+            var values = beliefs.Beliefs
+                .OrderByDescending(kv => kv.Value)
+                .Take(3)
+                .Select(kv => kv.Key)
+                .ToList();
+
+            string truth = $"A verdade é que {string.Join(" e ", values)} são revelações refletidas em {string.Join(", ", meaningfulSymbols)}.";
+
+            var newDoctrine = new Doctrine
+            {
+                Name = $"Doutrina de {meaningfulSymbols.FirstOrDefault() ?? "origem"}",
+                Tenets = new List<string>
+                {
+                    $"Jamais contrariar {values.FirstOrDefault() ?? "o instinto"}",
+                    $"Buscar o significado oculto de {meaningfulSymbols.LastOrDefault() ?? "tudo"}",
+                    "Toda dor carrega um símbolo sagrado"
+                },
+                OriginSymbol = meaningfulSymbols.FirstOrDefault() ?? "símbolo ancestral"
+            };
+
+            Doctrines.Add(newDoctrine);
+            CoreTruths.Add(truth);
+        }
+
+        public List<string> GetAllTenets()
+        {
+            return Doctrines.SelectMany(d => d.Tenets).Distinct().ToList();
+        }
+
+        public void PreachDoctrine(Person target)
+        {
+            if (!Doctrines.Any()) return;
+            var doctrine = Doctrines.Last();
+            foreach (var tenet in doctrine.Tenets)
+            {
+                target.Mind.DynamicBeliefs.AddBelief(tenet, 0.3f, "doutrina", "curiosity");
+            }
+
+            target.Mind.Memory.AddMemory($"Foi ensinado sobre a {doctrine.Name}", 0.3f, 0f, new() { "Doutrina" }, "other");
+        }
+    }
+}
+

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -35,6 +35,7 @@ namespace UltraWorldAI
         public DefenseMechanismSystem Defenses { get; private set; }
         public IntrospectionSystem Introspection { get; private set; }
         public CognitiveFeedbackSystem CognitiveFeedback { get; private set; }
+        public DoctrineSystem Doctrines { get; private set; }
 
         public Mind(Person person)
         {
@@ -69,6 +70,7 @@ namespace UltraWorldAI
             Defenses = new DefenseMechanismSystem();
             Introspection = new IntrospectionSystem();
             CognitiveFeedback = new CognitiveFeedbackSystem();
+            Doctrines = new DoctrineSystem();
         }
 
         public void Update()
@@ -109,6 +111,11 @@ namespace UltraWorldAI
                 Emotions.SetEmotion("sorrow", s);
             }
             Defenses.Decay();
+
+            if (new Random().NextDouble() < 0.01)
+            {
+                Doctrines.EvolveFromSymbolsAndBeliefs(Expressions, Beliefs);
+            }
         }
     }
 }

--- a/tests/UltraWorldAI.Tests/DoctrineSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrineSystemTests.cs
@@ -1,0 +1,36 @@
+using UltraWorldAI;
+using Xunit;
+
+public class DoctrineSystemTests
+{
+    [Fact]
+    public void EvolveCreatesDoctrineAndTruth()
+    {
+        var person = new Person("Guru");
+        person.Mind.Expressions.Symbols.Add(new PersonalSymbol { Motif = "fogo" });
+        person.Mind.Expressions.Symbols.Add(new PersonalSymbol { Motif = "espelho" });
+        person.Mind.Beliefs.UpdateBelief("Coragem", 0.9f);
+        var system = new DoctrineSystem();
+
+        system.EvolveFromSymbolsAndBeliefs(person.Mind.Expressions, person.Mind.Beliefs);
+
+        Assert.Single(system.Doctrines);
+        Assert.Single(system.CoreTruths);
+    }
+
+    [Fact]
+    public void PreachDoctrineAddsBeliefToTarget()
+    {
+        var teacher = new Person("Mestre");
+        teacher.Mind.Expressions.Symbols.Add(new PersonalSymbol { Motif = "fogo" });
+        teacher.Mind.Beliefs.UpdateBelief("Sabedoria", 0.8f);
+        var system = new DoctrineSystem();
+        system.EvolveFromSymbolsAndBeliefs(teacher.Mind.Expressions, teacher.Mind.Beliefs);
+
+        var follower = new Person("Disc\u00edpulo");
+        system.PreachDoctrine(follower);
+
+        Assert.NotEmpty(follower.Mind.DynamicBeliefs.Beliefs);
+        Assert.Contains(follower.Mind.Memory.Memories, m => m.Summary.Contains("Foi ensinado"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `DoctrineSystem` for evolving doctrinal beliefs from symbols
- integrate doctrine generation into `Mind`
- test new behaviour with `DoctrineSystemTests`

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68419cab91148323afb375f19064704d