### PR TITLE
Implement philosophical integrity system

### DIFF
--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -34,6 +34,8 @@ namespace UltraWorldAI
         public TraditionSystem Traditions { get; private set; }
         public ExternalSupportSystem ExternalSupport { get; private set; }
         public PhilosophySystem Philosophy { get; private set; }
+        public Thoughts.PhilosophicalIntegrity Integrity { get; private set; }
+        public float PhilosophicalIntegrityScore { get; private set; }
         public ContradictionSystem Contradictions { get; private set; }
         public DefenseMechanismSystem Defenses { get; private set; }
         public IntrospectionSystem Introspection { get; private set; }
@@ -58,6 +60,7 @@ namespace UltraWorldAI
             Narrative = new NarrativeEngine(person);
             IdeaNet = new IdeaNetwork();
             IdeaEngine = new IdeaEngine();
+            Integrity = new Thoughts.PhilosophicalIntegrity(IdeaEngine);
             ThoughtEngine = new ThoughtSystem();
             BrainMap = new BrainwireSystem();
             Intuition = new IntuitionSystem();
@@ -109,6 +112,7 @@ namespace UltraWorldAI
             Symbols.GenerateFromEmotion(Emotions);
             Symbols.IntegrateSymbolicMeaning(DynamicBeliefs);
             DynamicBeliefs.ResolveContradictions(Conflict, Emotions);
+            PhilosophicalIntegrityScore = Integrity.EvaluateConsistency();
             Philosophy.Update(this);
             InternalNarrative.GenerateReflection(this);
             InternalNarrative.InteractWithSubvoices(Subvoices);

--- a/src/UltraWorldAI/PhilosophicalIntegrity.cs
+++ b/src/UltraWorldAI/PhilosophicalIntegrity.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Thoughts
+{
+    public class PhilosophicalIntegrity
+    {
+        private readonly IdeaEngine _engine;
+
+        public PhilosophicalIntegrity(IdeaEngine ideaEngine)
+        {
+            _engine = ideaEngine;
+        }
+
+        public float EvaluateConsistency()
+        {
+            float totalConflict = 0f;
+            int pairs = 0;
+
+            foreach (var wire in _engine.BrainConnections)
+            {
+                var ideaA = _engine.GeneratedIdeas.FirstOrDefault(i => i.Title == wire.IdeaA);
+                var ideaB = _engine.GeneratedIdeas.FirstOrDefault(i => i.Title == wire.IdeaB);
+
+                if (ideaA != null && ideaB != null)
+                {
+                    float logicConflict = Math.Abs(ideaA.SymbolicPower - ideaB.SymbolicPower);
+                    float emotionGap = Math.Abs(ideaA.EmotionalCharge - ideaB.EmotionalCharge);
+                    float contradictionWeight = (logicConflict + emotionGap) * (1f - wire.Strength);
+
+                    wire.ConflictLevel = contradictionWeight;
+                    totalConflict += contradictionWeight;
+                    pairs++;
+                }
+            }
+
+            return pairs == 0 ? 0f : 1f - (totalConflict / pairs);
+        }
+
+        public List<Idea> GetContradictoryIdeas(float threshold = 0.5f)
+        {
+            return _engine.BrainConnections
+                .Where(w => w.ConflictLevel > threshold)
+                .SelectMany(w => new[]
+                {
+                    _engine.GeneratedIdeas.FirstOrDefault(i => i.Title == w.IdeaA),
+                    _engine.GeneratedIdeas.FirstOrDefault(i => i.Title == w.IdeaB)
+                })
+                .Where(i => i != null)
+                .Distinct()
+                .ToList()!;
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/PhilosophicalIntegrityTests.cs
+++ b/tests/UltraWorldAI.Tests/PhilosophicalIntegrityTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using UltraWorldAI.Thoughts;
+using Xunit;
+
+public class PhilosophicalIntegrityTests
+{
+    [Fact]
+    public void EvaluateConsistencyReturnsLowerScoreForConflictingIdeas()
+    {
+        var engine = new IdeaEngine();
+        engine.GeneratedIdeas.Add(new Idea { Title = "a", SymbolicPower = 0.1f, EmotionalCharge = 0.2f });
+        engine.GeneratedIdeas.Add(new Idea { Title = "b", SymbolicPower = 0.9f, EmotionalCharge = -0.5f });
+        engine.BrainConnections.Add(new Brainwire { IdeaA = "a", IdeaB = "b", Strength = 0.2f });
+
+        var integrity = new PhilosophicalIntegrity(engine);
+        var score = integrity.EvaluateConsistency();
+
+        Assert.True(score < 1f);
+        Assert.Equal(2, integrity.GetContradictoryIdeas().Count);
+    }
+
+    [Fact]
+    public void EvaluateConsistencyZeroWhenNoConnections()
+    {
+        var integrity = new PhilosophicalIntegrity(new IdeaEngine());
+        var score = integrity.EvaluateConsistency();
+        Assert.Equal(0f, score);
+    }
+}


### PR DESCRIPTION
## Summary
- add PhilosophicalIntegrity class to monitor conflicting ideas
- integrate system into Mind
- track philosophical consistency during updates
- test consistency evaluation with and without brainwire conflicts

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa5cfec48323ba759dfb27328c93