### PR TITLE
Implement InternalDialectics and fix legacy filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **InteractionSystem** permite comunicação simples entre agentes, afetando crenças e emoções.
 - **TraditionSystem** registra tradições e rituais, preservando legado emocional.
 - **LegacySystem** permite transmitir traços e memórias a novos personagens.
+- **PhilosophicalIntegrity** avalia a coerência entre ideias geradas.
+- **InternalDialectics** coloca ideias em confronto, permitindo sínteses ou reforço.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **xUnit tests** verificam memórias e resolução de contradições.
 

--- a/src/UltraWorldAI/IdeaNetwork.cs
+++ b/src/UltraWorldAI/IdeaNetwork.cs
@@ -7,7 +7,7 @@ namespace UltraWorldAI
     // Represents a lightweight associative network of ideas connected to memories and emotions
     public class IdeaNetwork
     {
-        public List<Idea> Ideas { get; } = new();
+        public List<NetworkIdea> Ideas { get; } = new();
         public List<IdeaLink> Brainwires { get; } = new();
 
         public void GenerateNewIdea(string seed, EmotionSystem emotions, MemorySystem memory, BeliefSystem beliefs)
@@ -20,7 +20,7 @@ namespace UltraWorldAI
             var beliefInfluence = beliefs.Beliefs.Keys
                 .FirstOrDefault(v => seed.Contains(v, StringComparison.OrdinalIgnoreCase)) ?? "neutro";
 
-            var idea = new Idea
+            var idea = new NetworkIdea
             {
                 Content = $"Ideia relacionada a '{seed}' influenciada por '{emotionalContext}' e crença '{beliefInfluence}'",
                 OriginEmotion = emotionalContext,
@@ -33,7 +33,7 @@ namespace UltraWorldAI
             CreateIdeaLinksFromIdea(idea);
         }
 
-        private void CreateIdeaLinksFromIdea(Idea idea)
+        private void CreateIdeaLinksFromIdea(NetworkIdea idea)
         {
             foreach (var mem in idea.RelatedMemorySummaries)
             {
@@ -67,7 +67,7 @@ namespace UltraWorldAI
         }
     }
 
-    public class Idea
+    public class NetworkIdea
     {
         public string Content { get; set; } = string.Empty;
         public string OriginEmotion { get; set; } = string.Empty;

--- a/src/UltraWorldAI/InternalDialectics.cs
+++ b/src/UltraWorldAI/InternalDialectics.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+
+namespace UltraWorldAI.Thoughts
+{
+    public class InternalDialectics
+    {
+        private readonly IdeaEngine _engine;
+
+        public InternalDialectics(IdeaEngine ideaEngine)
+        {
+            _engine = ideaEngine;
+        }
+
+        public string EngageDebate(string ideaATitle, string ideaBTitle)
+        {
+            var ideaA = _engine.GeneratedIdeas.FirstOrDefault(i => i.Title == ideaATitle);
+            var ideaB = _engine.GeneratedIdeas.FirstOrDefault(i => i.Title == ideaBTitle);
+            if (ideaA == null || ideaB == null)
+                return "Erro: uma das ideias não existe.";
+
+            var powerA = ideaA.EmotionalCharge + ideaA.SymbolicPower;
+            var powerB = ideaB.EmotionalCharge + ideaB.SymbolicPower;
+
+            if (Math.Abs(powerA - powerB) < 0.3f)
+            {
+                var newIdea = new Idea
+                {
+                    Title = $"Síntese_{ideaA.Title}_{ideaB.Title}",
+                    Description = $"Síntese entre '{ideaA.Title}' e '{ideaB.Title}'",
+                    EmotionalCharge = (ideaA.EmotionalCharge + ideaB.EmotionalCharge) / 2f,
+                    SymbolicPower = (ideaA.SymbolicPower + ideaB.SymbolicPower) / 2f
+                };
+                _engine.GeneratedIdeas.Add(newIdea);
+                return $"Nova ideia criada como síntese: {newIdea.Title}";
+            }
+
+            var winner = powerA > powerB ? ideaA : ideaB;
+            winner.SymbolicPower += 0.2f;
+            winner.EmotionalCharge += 0.1f;
+            return $"Ideia vencedora do embate: {winner.Title}";
+        }
+    }
+}

--- a/src/UltraWorldAI/LegacySystem.cs
+++ b/src/UltraWorldAI/LegacySystem.cs
@@ -17,6 +17,7 @@ namespace UltraWorldAI
 
             MemeticInfluences = mind.Beliefs.Beliefs
                 .Where(kv => kv.Key.Contains("Visão", StringComparison.OrdinalIgnoreCase) ||
+                             kv.Key.Contains("Visao", StringComparison.OrdinalIgnoreCase) ||
                              kv.Key.Contains("doutrina", StringComparison.OrdinalIgnoreCase) ||
                              kv.Key.Contains("tradição", StringComparison.OrdinalIgnoreCase))
                 .Select(kv => kv.Key)

--- a/tests/UltraWorldAI.Tests/InternalDialecticsTests.cs
+++ b/tests/UltraWorldAI.Tests/InternalDialecticsTests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using UltraWorldAI;
+using UltraWorldAI.Thoughts;
+using Xunit;
+
+public class InternalDialecticsTests
+{
+    [Fact]
+    public void EngageDebateCreatesSynthesisWhenBalanced()
+    {
+        var engine = new IdeaEngine();
+        engine.GeneratedIdeas.Add(new Idea { Title = "A", EmotionalCharge = 0.5f, SymbolicPower = 0.5f });
+        engine.GeneratedIdeas.Add(new Idea { Title = "B", EmotionalCharge = 0.6f, SymbolicPower = 0.4f });
+        var dialectics = new InternalDialectics(engine);
+
+        var result = dialectics.EngageDebate("A", "B");
+
+        Assert.Contains("Síntese", result);
+        Assert.Equal(3, engine.GeneratedIdeas.Count);
+    }
+
+    [Fact]
+    public void EngageDebateBoostsWinnerWhenPowerDiffers()
+    {
+        var engine = new IdeaEngine();
+        engine.GeneratedIdeas.Add(new Idea { Title = "X", EmotionalCharge = 0.9f, SymbolicPower = 0.8f });
+        engine.GeneratedIdeas.Add(new Idea { Title = "Y", EmotionalCharge = 0.2f, SymbolicPower = 0.1f });
+        var dialectics = new InternalDialectics(engine);
+
+        var result = dialectics.EngageDebate("X", "Y");
+
+        Assert.Contains("Ideia vencedora", result);
+        var winner = engine.GeneratedIdeas.First(i => i.Title == "X");
+        Assert.True(winner.SymbolicPower > 0.8f);
+    }
+}


### PR DESCRIPTION
## Summary
- rename `Idea` in IdeaNetwork to `NetworkIdea` to avoid conflicts
- adjust LegacySystem to accept beliefs spelled `Visao`
- add `InternalDialectics` class for debating ideas
- document new features in README
- add unit tests for InternalDialectics

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6841ab563a7883238b0b70c5b4b1b1eb