### PR TITLE
Add ethical judgment and narrative systems

### DIFF
--- a/src/UltraWorldAI/EthicalJudgment.cs
+++ b/src/UltraWorldAI/EthicalJudgment.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Thoughts
+{
+    public class EthicalJudgment
+    {
+        private readonly IdeaEngine _engine;
+        private readonly float _moralSensitivity;
+
+        public EthicalJudgment(IdeaEngine ideaEngine, float sensitivity = 0.5f)
+        {
+            _engine = ideaEngine;
+            _moralSensitivity = sensitivity;
+        }
+
+        public string JudgeAction(string actionSymbol, List<string> involvedIdeas)
+        {
+            float support = 0f;
+            float opposition = 0f;
+
+            foreach (var idea in _engine.GeneratedIdeas)
+            {
+                if (involvedIdeas.Contains(idea.Title))
+                {
+                    if (idea.EmotionalCharge >= _moralSensitivity)
+                        support += idea.SymbolicPower;
+                    else
+                        opposition += idea.SymbolicPower;
+                }
+            }
+
+            if (support - opposition > 0.3f)
+                return $"Ação '{actionSymbol}' julgada como ÉTICA.";
+            if (opposition - support > 0.3f)
+                return $"Ação '{actionSymbol}' julgada como IMORAL.";
+            return $"Ação '{actionSymbol}' julgada como AMBÍGUA.";
+        }
+    }
+}

--- a/src/UltraWorldAI/HistoricalIdentity.cs
+++ b/src/UltraWorldAI/HistoricalIdentity.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Thoughts
+{
+    public class HistoricalIdentity
+    {
+        public List<string> LifeEvents { get; } = new();
+        public string MythicTitle { get; private set; } = "Anônimo";
+        public string LegacyPhrase { get; private set; } = "Nada será lembrado.";
+
+        public void RegisterEvent(string symbolicEvent)
+        {
+            LifeEvents.Add($"{DateTime.Now:yyyy-MM-dd} - {symbolicEvent}");
+            UpdateLegacy();
+        }
+
+        private void UpdateLegacy()
+        {
+            if (LifeEvents.Count > 3)
+            {
+                MythicTitle = $"Aquele que {ExtractEssence()}";
+                LegacyPhrase = $"Seu nome ecoa por \"{LifeEvents.Count}\" memórias.";
+            }
+        }
+
+        private string ExtractEssence()
+        {
+            if (LifeEvents.Exists(e => e.Contains("sacrifício"))) return "se sacrificou por outros";
+            if (LifeEvents.Exists(e => e.Contains("construiu"))) return "ergueu algo eterno";
+            if (LifeEvents.Exists(e => e.Contains("quebrou um tabu"))) return "desafiou os símbolos";
+            return "viveu intensamente";
+        }
+    }
+}

--- a/src/UltraWorldAI/IdeaEngine.cs
+++ b/src/UltraWorldAI/IdeaEngine.cs
@@ -64,6 +64,8 @@ namespace UltraWorldAI
             idea.IsExpressed = true;
             idea.InfluenceOnWorld += (float)_random.NextDouble();
             mind.Memory.AddMemory($"Expressou a ideia '{idea.Title}'", 0.4f, idea.EmotionalCharge, new() { "Ideia" }, "ideia");
+            mind.History.RegisterEvent($"Expressou a ideia '{idea.Title}'");
+            mind.LifeNarrative.UpdateNarrative();
         }
     }
 }

--- a/src/UltraWorldAI/LifeNarrative.cs
+++ b/src/UltraWorldAI/LifeNarrative.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Thoughts
+{
+    public class LifeNarrative
+    {
+        private readonly IdeaEngine _engine;
+        private readonly List<string> _narrativeFragments = new();
+
+        public string CorePurpose { get; private set; } = "Desconhecido";
+        public string SelfNarrative => string.Join(" ", _narrativeFragments);
+
+        public LifeNarrative(IdeaEngine ideaEngine)
+        {
+            _engine = ideaEngine;
+        }
+
+        public void UpdateNarrative()
+        {
+            _narrativeFragments.Clear();
+            var keyIdeas = _engine.GeneratedIdeas
+                .Where(i => i.IsExpressed && (i.SymbolicPower + i.EmotionalCharge) > 1.0f)
+                .OrderByDescending(i => i.SymbolicPower + i.EmotionalCharge)
+                .Take(5)
+                .ToList();
+
+            foreach (var idea in keyIdeas)
+            {
+                _narrativeFragments.Add($"\"{idea.Title}\" moldou meu caminho.");
+            }
+
+            CorePurpose = keyIdeas.Count > 0
+                ? $"Manter vivo o valor de \"{keyIdeas.First().Title}\"."
+                : "Buscar sentido.";
+        }
+    }
+}

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -42,6 +42,9 @@ namespace UltraWorldAI
         public CognitiveFeedbackSystem CognitiveFeedback { get; private set; }
         public DoctrineSystem Doctrines { get; private set; }
         public LegacySystem Legacy { get; private set; }
+        public Thoughts.EthicalJudgment Ethics { get; private set; }
+        public Thoughts.LifeNarrative LifeNarrative { get; private set; }
+        public Thoughts.HistoricalIdentity History { get; private set; }
 
         public Mind(Person person)
         {
@@ -81,6 +84,9 @@ namespace UltraWorldAI
             CognitiveFeedback = new CognitiveFeedbackSystem();
             Doctrines = new DoctrineSystem();
             Legacy = new LegacySystem();
+            Ethics = new Thoughts.EthicalJudgment(IdeaEngine);
+            LifeNarrative = new Thoughts.LifeNarrative(IdeaEngine);
+            History = new Thoughts.HistoricalIdentity();
         }
 
         public void Update()
@@ -145,6 +151,8 @@ namespace UltraWorldAI
                     Traditions.CreateTradition("lembrança", "manter a conexão com o passado", memory.Summary);
                 }
             }
+
+            LifeNarrative.UpdateNarrative();
         }
     }
 }

--- a/tests/UltraWorldAI.Tests/EthicalJudgmentTests.cs
+++ b/tests/UltraWorldAI.Tests/EthicalJudgmentTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using UltraWorldAI.Thoughts;
+using Xunit;
+
+public class EthicalJudgmentTests
+{
+    [Fact]
+    public void JudgeActionReturnsEthicalForSupportedIdeas()
+    {
+        var engine = new IdeaEngine();
+        engine.GeneratedIdeas.Add(new Idea { Title = "A", EmotionalCharge = 0.6f, SymbolicPower = 0.7f });
+        var judge = new EthicalJudgment(engine);
+        var result = judge.JudgeAction("acao", new List<string> { "A" });
+        Assert.Contains("ÉTICA", result);
+    }
+
+    [Fact]
+    public void JudgeActionReturnsImoralForOpposingIdeas()
+    {
+        var engine = new IdeaEngine();
+        engine.GeneratedIdeas.Add(new Idea { Title = "X", EmotionalCharge = 0.1f, SymbolicPower = 0.9f });
+        var judge = new EthicalJudgment(engine);
+        var result = judge.JudgeAction("acao", new List<string> { "X" });
+        Assert.Contains("IMORAL", result);
+    }
+}

--- a/tests/UltraWorldAI.Tests/HistoricalIdentityTests.cs
+++ b/tests/UltraWorldAI.Tests/HistoricalIdentityTests.cs
@@ -1,0 +1,18 @@
+using UltraWorldAI.Thoughts;
+using Xunit;
+
+public class HistoricalIdentityTests
+{
+    [Fact]
+    public void RegisterEventBuildsLegacy()
+    {
+        var history = new HistoricalIdentity();
+        history.RegisterEvent("construiu um templo");
+        history.RegisterEvent("fez um sacrifício");
+        history.RegisterEvent("quebrou um tabu");
+        history.RegisterEvent("construiu um monumento");
+        Assert.NotEqual("Anônimo", history.MythicTitle);
+        Assert.Equal(4, history.LifeEvents.Count);
+        Assert.Contains("memórias", history.LegacyPhrase);
+    }
+}

--- a/tests/UltraWorldAI.Tests/LifeNarrativeTests.cs
+++ b/tests/UltraWorldAI.Tests/LifeNarrativeTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI;
+using UltraWorldAI.Thoughts;
+using Xunit;
+
+public class LifeNarrativeTests
+{
+    [Fact]
+    public void UpdateNarrativeGeneratesPurpose()
+    {
+        var engine = new IdeaEngine();
+        engine.GeneratedIdeas.Add(new Idea { Title = "Amor", SymbolicPower = 0.6f, EmotionalCharge = 0.6f, IsExpressed = true });
+        var narrative = new LifeNarrative(engine);
+        narrative.UpdateNarrative();
+        Assert.Contains("moldou meu caminho", narrative.SelfNarrative);
+        Assert.NotEqual("Desconhecido", narrative.CorePurpose);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EthicalJudgment`, `LifeNarrative` and `HistoricalIdentity` classes
- integrate new systems into `Mind` and `IdeaEngine`
- register expressed ideas as life events
- add unit tests for the new components

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841afce67ac8323a30f630f9c47e570