### PR TITLE
Add taboo system features

### DIFF
--- a/src/UltraWorldAI/CultureSystem.cs
+++ b/src/UltraWorldAI/CultureSystem.cs
@@ -8,7 +8,7 @@ namespace UltraWorldAI
     {
         public string Name { get; set; } = string.Empty;
         public List<string> CoreValues { get; set; } = new();
-        public List<Taboo> Taboos { get; set; } = new();
+        public List<string> Taboos { get; set; } = new();
         public List<Tradition> Traditions { get; set; } = new();
         public string AestheticStyle { get; set; } = string.Empty;
         public CalendarType CalendarType { get; set; } = CalendarType.Lunar;
@@ -21,11 +21,6 @@ namespace UltraWorldAI
     {
         public string Name { get; set; } = string.Empty;
         public string Season { get; set; } = string.Empty;
-    }
-
-    public class Taboo
-    {
-        public string Description { get; set; } = string.Empty;
     }
 
     public class CultureSystem

--- a/src/UltraWorldAI/TabooManager.cs
+++ b/src/UltraWorldAI/TabooManager.cs
@@ -2,9 +2,30 @@ namespace UltraWorldAI
 {
     public static class TabooManager
     {
-        public static void AddTaboo(Culture culture, string description)
+        public static void AddTaboo(Culture culture, string taboo)
         {
-            culture.Taboos.Add(new Taboo { Description = description });
+            if (!culture.Taboos.Contains(taboo))
+                culture.Taboos.Add(taboo);
+        }
+
+        public static void MutateTaboos(Culture culture)
+        {
+            for (int i = 0; i < culture.Taboos.Count; i++)
+            {
+                var original = culture.Taboos[i];
+                if (original.Contains("nome"))
+                {
+                    culture.Taboos[i] = original.Replace("nome", "eco de identidade");
+                }
+            }
+
+            if (!culture.Taboos.Contains("Tocar o silêncio ritual"))
+                culture.Taboos.Add("Tocar o silêncio ritual");
+        }
+
+        public static string DescribeTaboos(Culture culture)
+        {
+            return $"A cultura {culture.Name} considera tabus: {string.Join(", ", culture.Taboos)}";
         }
     }
 }

--- a/tests/UltraWorldAI.Tests/TabooManagerTests.cs
+++ b/tests/UltraWorldAI.Tests/TabooManagerTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using Xunit;
+
+public class TabooManagerTests
+{
+    [Fact]
+    public void AddTabooDoesNotDuplicate()
+    {
+        var culture = new Culture { Name = "Teste" };
+        TabooManager.AddTaboo(culture, "Falar o nome dos mortos");
+        TabooManager.AddTaboo(culture, "Falar o nome dos mortos");
+        Assert.Single(culture.Taboos);
+    }
+
+    [Fact]
+    public void MutateTaboosTransformsAndAdds()
+    {
+        var culture = new Culture
+        {
+            Name = "Mutante",
+            Taboos = new List<string> { "pronunciar o nome sagrado" }
+        };
+        TabooManager.MutateTaboos(culture);
+        Assert.Contains("eco de identidade", culture.Taboos[0]);
+        Assert.Contains("Tocar o silêncio ritual", culture.Taboos);
+    }
+
+    [Fact]
+    public void DescribeTaboosListsTaboos()
+    {
+        var culture = new Culture { Name = "Narrativa" };
+        TabooManager.AddTaboo(culture, "Beber em jejum");
+        var desc = TabooManager.DescribeTaboos(culture);
+        Assert.Contains("Beber em jejum", desc);
+        Assert.Contains("Narrativa", desc);
+    }
+}


### PR DESCRIPTION
## Summary
- allow cultures to store taboos as strings
- expand `TabooManager` with mutate and describe helpers
- test taboo operations

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb89085c83238f9b51236e0a9259