### PR TITLE
Add CultureInfluence system

### DIFF
--- a/src/UltraWorldAI/CultureInfluence.cs
+++ b/src/UltraWorldAI/CultureInfluence.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+
+namespace UltraWorldAI
+{
+    public static class CultureInfluence
+    {
+        public static void ApplyCultureToMind(Culture culture, Mind mind)
+        {
+            foreach (var value in culture.CoreValues)
+            {
+                mind.IdeaEngine.GenerateIdea($"Valor cultural: {value}", new() { value }, 0.4f, 0.6f);
+            }
+
+            foreach (var taboo in culture.Taboos)
+            {
+                mind.IdeaEngine.GenerateIdea($"Tabu presente: {taboo}", new() { taboo }, 0.6f, 0.5f);
+            }
+
+            foreach (var ritual in culture.Traditions.SelectMany(t => t.Rituals).Select(r => r.Name))
+            {
+                mind.IdeaEngine.GenerateIdea($"Ritual observado: {ritual}", new() { ritual }, 0.5f, 0.4f);
+            }
+        }
+
+        public static void UpdateCultureFromMind(Mind mind, Culture culture)
+        {
+            var strongIdeas = mind.IdeaEngine.GeneratedIdeas
+                .Where(i => i.IsExpressed && i.SymbolicPower > 0.7f)
+                .Select(i => i.Title)
+                .ToList();
+
+            foreach (var idea in strongIdeas)
+            {
+                if (!culture.AssociatedIdeas.Contains(idea))
+                {
+                    culture.AssociatedIdeas.Add(idea);
+                    culture.CoreValues.Add($"Expressão: {idea}");
+                }
+            }
+
+            if (strongIdeas.Count > 3 && culture.Traditions.All(t => t.Name != "Ritual da Palavra Viva"))
+            {
+                culture.Traditions.Add(new Tradition
+                {
+                    Name = "Ritual da Palavra Viva",
+                    Purpose = "celebrar ideias",
+                    OriginStory = "Influencia da mente",
+                    Rituals = new()
+                    {
+                        new RitualInstance
+                        {
+                            Name = "Entoar a Palavra",
+                            Date = DateTime.Now,
+                            EmotionTone = "inspirado",
+                            PerformedBy = mind.PersonReference.Name
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/CultureInfluenceTests.cs
+++ b/tests/UltraWorldAI.Tests/CultureInfluenceTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using Xunit;
+
+public class CultureInfluenceTests
+{
+    [Fact]
+    public void ApplyCultureToMindGeneratesIdeas()
+    {
+        var culture = new Culture
+        {
+            CoreValues = new List<string> { "Respeito" },
+            Taboos = new List<string> { "Mentir" },
+            Traditions = new List<Tradition>
+            {
+                new() { Name = "Saudacao" , Rituals = new List<RitualInstance>() }
+            }
+        };
+        var person = new Person("CulturalMind");
+
+        CultureInfluence.ApplyCultureToMind(culture, person.Mind);
+
+        Assert.Contains(person.Mind.IdeaEngine.GeneratedIdeas, i => i.Title.Contains("Valor cultural: Respeito"));
+        Assert.Contains(person.Mind.IdeaEngine.GeneratedIdeas, i => i.Title.Contains("Tabu presente: Mentir"));
+        Assert.Contains(person.Mind.IdeaEngine.GeneratedIdeas, i => i.Title.Contains("Ritual observado: Saudacao"));
+    }
+
+    [Fact]
+    public void UpdateCultureFromMindAddsIdeasAndRitual()
+    {
+        var culture = new Culture();
+        var mind = new Person("Pioneiro").Mind;
+        mind.IdeaEngine.GeneratedIdeas.AddRange(new[]
+        {
+            new Idea { Title = "Visao", IsExpressed = true, SymbolicPower = 0.8f },
+            new Idea { Title = "Canto", IsExpressed = true, SymbolicPower = 0.9f },
+            new Idea { Title = "Eco", IsExpressed = true, SymbolicPower = 0.8f },
+            new Idea { Title = "Chama", IsExpressed = true, SymbolicPower = 0.85f }
+        });
+
+        CultureInfluence.UpdateCultureFromMind(mind, culture);
+
+        Assert.Contains("Visao", culture.AssociatedIdeas);
+        Assert.Contains(culture.CoreValues, v => v.Contains("Visao"));
+        Assert.Contains(culture.Traditions, t => t.Name == "Ritual da Palavra Viva");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CultureInfluence` to tie together cultures and minds
- generate ideas from culture values, taboos and rituals
- allow strong ideas to modify a culture
- test culture influence logic

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c320dc7c8323929fecda47655fd9