### PR TITLE
Implement Cultural Reformation system

### DIFF
--- a/src/UltraWorldAI/CulturalReformation.cs
+++ b/src/UltraWorldAI/CulturalReformation.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+
+namespace UltraWorldAI;
+
+public static class CulturalReformation
+{
+    public static void AttemptReformation(Mind mind, Culture culture)
+    {
+        var reformers = mind.IdeaEngine.GeneratedIdeas
+            .Where(i => i.IsExpressed && i.SymbolicPower > 0.6f)
+            .ToList();
+
+        foreach (var idea in reformers)
+        {
+            bool isTaboo = culture.Taboos.Any(t => idea.Title.Contains(t));
+
+            if (!isTaboo && !culture.CoreValues.Contains(idea.Title))
+            {
+                culture.CoreValues.Add(idea.Title);
+                if (culture.Traditions.All(t => t.Name != $"Celebracao da Ideia: {idea.Title}"))
+                {
+                    var tradition = new Tradition
+                    {
+                        Name = $"Celebracao da Ideia: {idea.Title}",
+                        Purpose = "celebrar inovacao",
+                        OriginStory = idea.Title,
+                        Rituals = new()
+                        {
+                            new RitualInstance
+                            {
+                                Name = $"Refletir sobre {idea.Title}",
+                                Date = DateTime.Now,
+                                EmotionTone = "inspirado",
+                                PerformedBy = mind.PersonReference.Name
+                            }
+                        }
+                    };
+                    culture.Traditions.Add(tradition);
+                }
+            }
+            else if (isTaboo)
+            {
+                mind.Stress.AddStress(0.1f);
+            }
+        }
+
+        if (culture.CoreValues.Count > 7 && culture.Traditions.All(t => t.Name != "Festa da Nova Consciencia"))
+        {
+            var fest = new Tradition
+            {
+                Name = "Festa da Nova Consciencia",
+                Purpose = "marcar reforma cultural",
+                OriginStory = "acumulo de reformas",
+                Rituals = new()
+                {
+                    new RitualInstance
+                    {
+                        Name = "Celebracoes Continuas",
+                        Date = DateTime.Now,
+                        EmotionTone = "festivo",
+                        PerformedBy = "sistema"
+                    }
+                }
+            };
+            culture.Traditions.Add(fest);
+        }
+    }
+}

--- a/src/UltraWorldAI/CultureSystem.cs
+++ b/src/UltraWorldAI/CultureSystem.cs
@@ -77,6 +77,8 @@ namespace UltraWorldAI
                     Cultures.Add(fragment);
                 }
 
+                CulturalReformation.AttemptReformation(mind, culture);
+
                 if (_random.NextDouble() < 0.1)
                 {
                     culture.CoreValues.Add($"valor{_random.Next(100)}");

--- a/tests/UltraWorldAI.Tests/CulturalReformationTests.cs
+++ b/tests/UltraWorldAI.Tests/CulturalReformationTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using Xunit;
+
+public class CulturalReformationTests
+{
+    [Fact]
+    public void IntegratesExpressedIdeas()
+    {
+        var mind = new Person("Reformador").Mind;
+        mind.IdeaEngine.GeneratedIdeas.Add(new Idea { Title = "Harmonia", IsExpressed = true, SymbolicPower = 0.7f });
+        var culture = new Culture();
+
+        CulturalReformation.AttemptReformation(mind, culture);
+
+        Assert.Contains("Harmonia", culture.CoreValues);
+    }
+
+    [Fact]
+    public void TabooIdeasIncreaseStress()
+    {
+        var mind = new Person("Tabu").Mind;
+        mind.IdeaEngine.GeneratedIdeas.Add(new Idea { Title = "Segredo Proibido", IsExpressed = true, SymbolicPower = 0.7f });
+        var culture = new Culture { Taboos = new List<string> { "Proibido" } };
+
+        CulturalReformation.AttemptReformation(mind, culture);
+
+        Assert.True(mind.Stress.CurrentStressLevel > AIConfig.MinStress);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CulturalReformation` system to integrate new ideas into cultures
- hook cultural reformation into culture evolution logic
- verify integration through new unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal` *(fails: CulturalDivergence build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c425e35c8323b9ef308b5da83ad3