### PR TITLE
Implement cultural collapse system

### DIFF
--- a/src/UltraWorldAI/CulturalCollapse.cs
+++ b/src/UltraWorldAI/CulturalCollapse.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+
+namespace UltraWorldAI;
+
+public static class CulturalCollapse
+{
+    public static bool CheckCollapse(Culture culture)
+    {
+        bool valuesEmpty = culture.CoreValues.Count == 0;
+        bool ritualsForgotten = !culture.Traditions.Any() || culture.Traditions.All(t => t.Rituals.Count == 0);
+        bool taboosContradictValues = culture.Taboos.Any(t => culture.CoreValues.Any(v => t.Contains(v)));
+
+        return valuesEmpty || ritualsForgotten || taboosContradictValues;
+    }
+
+    public static void CollapseCulture(Culture culture)
+    {
+        culture.Name += " (Extinta)";
+        culture.CoreValues.Clear();
+        culture.Traditions.Clear();
+        culture.Taboos.Clear();
+        culture.AestheticStyle = "Ruína da memória";
+        culture.CulturalCalendar = new Calendar(culture.CalendarType);
+        culture.AssociatedIdeas.Add("Desintegração cultural");
+    }
+
+    public static string DescribeCollapse(Culture culture)
+    {
+        return $"A cultura '{culture.Name}' colapsou por perda simbólica e contradição ritual.";
+    }
+}

--- a/tests/UltraWorldAI.Tests/CulturalCollapseTests.cs
+++ b/tests/UltraWorldAI.Tests/CulturalCollapseTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI;
+using Xunit;
+
+public class CulturalCollapseTests
+{
+    [Fact]
+    public void CheckCollapseDetectsEntropy()
+    {
+        var culture = new Culture
+        {
+            Taboos = new List<string> { "Honra" },
+            Traditions = new List<Tradition> { new() { Name = "T", Rituals = new List<RitualInstance>() } }
+        };
+
+        Assert.True(CulturalCollapse.CheckCollapse(culture));
+
+        var stable = new Culture
+        {
+            CoreValues = new List<string> { "Honra" },
+            Traditions = new List<Tradition> { new() { Name = "R", Rituals = new List<RitualInstance> { new() { Name = "Cerimonia", Date = DateTime.Now, EmotionTone = "alegre", PerformedBy = "tester" } } } }
+        };
+
+        Assert.False(CulturalCollapse.CheckCollapse(stable));
+    }
+
+    [Fact]
+    public void CollapseCultureClearsData()
+    {
+        var culture = new Culture
+        {
+            Name = "Memoria",
+            CoreValues = new List<string> { "Valor" },
+            Traditions = new List<Tradition> { new() { Name = "R", Rituals = new List<RitualInstance> { new() { Name = "Cerimonia", Date = DateTime.Now, EmotionTone = "intenso", PerformedBy = "x" } } } },
+            Taboos = new List<string> { "Valor" },
+            AssociatedIdeas = new List<string>()
+        };
+
+        CulturalCollapse.CollapseCulture(culture);
+
+        Assert.Contains("(Extinta)", culture.Name);
+        Assert.Empty(culture.CoreValues);
+        Assert.Empty(culture.Traditions);
+        Assert.Empty(culture.Taboos);
+        Assert.Contains("Desintegração cultural", culture.AssociatedIdeas);
+        Assert.Equal("Ruína da memória", culture.AestheticStyle);
+    }
+
+    [Fact]
+    public void DescribeCollapseMentionsCulture()
+    {
+        var culture = new Culture { Name = "Arcadia" };
+        var desc = CulturalCollapse.DescribeCollapse(culture);
+        Assert.Contains("Arcadia", desc);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CulturalCollapse` subsystem to manage collapsing cultures
- test detection, collapse, and description behaviors

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d61e4ff08323a52c51ff4eaf29e2