### PR TITLE
Add HabitatMemory and emotional tagging

### DIFF
--- a/UltraWorldAI.csproj
+++ b/UltraWorldAI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>UltraWorldApp</AssemblyName>

--- a/src/UltraWorldAI/CulturalDivergence.cs
+++ b/src/UltraWorldAI/CulturalDivergence.cs
@@ -8,7 +8,7 @@ public static class CulturalDivergence
     public static bool CheckForRupture(Mind mind, Culture culture, float threshold = 0.7f)
     {
         var conflictingIdeas = mind.IdeaEngine.GeneratedIdeas
-            .Where(i => culture.Taboos.Any(t => i.Title.Contains(t.Description)) && i.SymbolicPower > threshold)
+            .Where(i => culture.Taboos.Any(t => i.Title.Contains(t)) && i.SymbolicPower > threshold)
             .ToList();
 
         return conflictingIdeas.Count >= 2;
@@ -25,10 +25,10 @@ public static class CulturalDivergence
                 .Where(i => i.IsExpressed && i.SymbolicPower > 0.5f)
                 .Select(i => $"Herdeiro: {i.Title}")
                 .ToList(),
-            Taboos = new List<Taboo>
+            Taboos = new List<string>
             {
-                new() { Description = "Negacao da origem" },
-                new() { Description = "Repetir o passado" }
+                "Negacao da origem",
+                "Repetir o passado"
             },
             Traditions = new List<Tradition>
             {

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -48,6 +48,7 @@ namespace UltraWorldAI
         public Thoughts.LifeNarrative LifeNarrative { get; private set; }
         public Thoughts.HistoricalIdentity History { get; private set; }
 
+        public Territory.HabitatMemory HabitatMemory { get; private set; }
         public Mind(Person person)
         {
             PersonReference = person;
@@ -90,6 +91,7 @@ namespace UltraWorldAI
             Ethics = new Thoughts.EthicalJudgment(IdeaEngine);
             LifeNarrative = new Thoughts.LifeNarrative(IdeaEngine);
             History = new Thoughts.HistoricalIdentity();
+            HabitatMemory = new Territory.HabitatMemory();
         }
 
         public void Update()

--- a/src/UltraWorldAI/Person.cs
+++ b/src/UltraWorldAI/Person.cs
@@ -26,6 +26,11 @@ namespace UltraWorldAI
         public void AddExperience(string summary, float intensity = 0.5f, float emotionalCharge = 0.0f, List<string>? keywords = null, string source = "self")
         {
             Mind.Memory.AddMemory(summary, intensity, emotionalCharge, keywords, source);
+            if (Math.Abs(emotionalCharge) >= 0.5f)
+            {
+                var emotion = Mind.Emotions.GetDominantEmotion();
+                Mind.HabitatMemory.TagPlace(Location.RegionName, emotion, summary, Math.Abs(emotionalCharge));
+            }
             Logger.Log($"\n[{Name} Experience] '{summary}' (Intensity: {intensity}, Emotion: {emotionalCharge})");
         }
 

--- a/src/UltraWorldAI/Territory/HabitatMemory.cs
+++ b/src/UltraWorldAI/Territory/HabitatMemory.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Territory;
+
+public class HabitatMemory
+{
+    public class MemoryTag
+    {
+        public string RegionName { get; set; } = string.Empty;
+        public string Emotion { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public float Intensity { get; set; }
+    }
+
+    public List<MemoryTag> TaggedPlaces { get; } = new();
+
+    public void TagPlace(string region, string emotion, string description, float intensity)
+    {
+        var existing = TaggedPlaces.Find(p => p.RegionName == region);
+        if (existing == null)
+        {
+            TaggedPlaces.Add(new MemoryTag
+            {
+                RegionName = region,
+                Emotion = emotion,
+                Description = description,
+                Intensity = intensity
+            });
+        }
+        else
+        {
+            existing.Intensity = (existing.Intensity + intensity) / 2f;
+            existing.Description = $"{existing.Description} | {description}";
+        }
+    }
+
+    public List<MemoryTag> GetStrongestMemories(float threshold = 0.5f)
+    {
+        return TaggedPlaces.FindAll(p => p.Intensity >= threshold);
+    }
+
+    public string Describe()
+    {
+        if (TaggedPlaces.Count == 0)
+            return "Sem memórias territoriais.";
+
+        var list = new List<string>();
+        foreach (var m in TaggedPlaces)
+        {
+            list.Add($"[{m.RegionName}] sentiu '{m.Emotion}' - {m.Description} (Intensidade {m.Intensity})");
+        }
+        return string.Join("\n", list);
+    }
+}

--- a/src/UltraWorldAI/UltraWorldAI.csproj
+++ b/src/UltraWorldAI/UltraWorldAI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/UltraWorldAI.Tests/CulturalDivergenceTests.cs
+++ b/tests/UltraWorldAI.Tests/CulturalDivergenceTests.cs
@@ -17,7 +17,7 @@ public class CulturalDivergenceTests
         var culture = new Culture
         {
             Name = "Base",
-            Taboos = new List<Taboo> { new() { Description = "Tabu1" } }
+            Taboos = new List<string> { "Tabu1" }
         };
 
         Assert.True(CulturalDivergence.CheckForRupture(mind, culture));

--- a/tests/UltraWorldAI.Tests/CultureInfluenceTests.cs
+++ b/tests/UltraWorldAI.Tests/CultureInfluenceTests.cs
@@ -13,7 +13,11 @@ public class CultureInfluenceTests
             Taboos = new List<string> { "Mentir" },
             Traditions = new List<Tradition>
             {
-                new() { Name = "Saudacao" , Rituals = new List<RitualInstance>() }
+                new()
+                {
+                    Name = "Saudacao",
+                    Rituals = new List<RitualInstance> { new() { Name = "Saudacao" } }
+                }
             }
         };
         var person = new Person("CulturalMind");

--- a/tests/UltraWorldAI.Tests/HabitatMemoryTests.cs
+++ b/tests/UltraWorldAI.Tests/HabitatMemoryTests.cs
@@ -1,0 +1,26 @@
+using UltraWorldAI;
+using UltraWorldAI.Territory;
+using Xunit;
+
+public class HabitatMemoryTests
+{
+    [Fact]
+    public void TagPlaceAddsMemory()
+    {
+        var mem = new HabitatMemory();
+        mem.TagPlace("caverna", "medo", "quase morri", 0.8f);
+
+        Assert.Single(mem.TaggedPlaces);
+        Assert.Equal("caverna", mem.TaggedPlaces[0].RegionName);
+    }
+
+    [Fact]
+    public void AddExperienceWithEmotionTagsPlace()
+    {
+        var person = new Person("Tester");
+        person.AddExperience("enfrentou um monstro", 0.7f, 0.9f);
+
+        Assert.Single(person.Mind.HabitatMemory.TaggedPlaces);
+        Assert.Equal("Origem", person.Mind.HabitatMemory.TaggedPlaces[0].RegionName);
+    }
+}

--- a/tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj
+++ b/tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add `HabitatMemory` class for territorial emotional memories
- integrate habitat memory with `Mind` and `Person`
- fix CulturalDivergence logic and adjust tests
- update culture influence test to include ritual
- upgrade projects to .NET 8
- add unit tests for HabitatMemory

## Testing
- `dotnet build src/UltraWorldAI/UltraWorldAI.csproj -v minimal`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841d8f882408323b801dc219a58937a