### PR TITLE
Add symbolic ConstructionEngine

### DIFF
--- a/src/UltraWorldAI/Territory/ConstructionEngine.cs
+++ b/src/UltraWorldAI/Territory/ConstructionEngine.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Territory;
+
+public static class ConstructionEngine
+{
+    public class Structure
+    {
+        public string Type { get; set; } = string.Empty;
+        public string Region { get; set; } = string.Empty;
+        public string SymbolicPurpose { get; set; } = string.Empty;
+        public float EmotionalCharge { get; set; }
+        public string CreatedBy { get; set; } = string.Empty;
+    }
+
+    public static List<Structure> BuiltStructures { get; } = new();
+
+    public static void BuildStructure(Mind mind, SpatialIdentity location, string purpose)
+    {
+        string type = ClassifyStructure(purpose);
+        string dominantEmotion = mind.Emotions.GetDominantEmotion();
+        float emotion = mind.Emotions.GetEmotion(dominantEmotion);
+
+        var structure = new Structure
+        {
+            Type = type,
+            Region = location.RegionName,
+            SymbolicPurpose = purpose,
+            EmotionalCharge = emotion,
+            CreatedBy = mind.PersonReference.Name
+        };
+
+        BuiltStructures.Add(structure);
+
+        mind.Memory.AddMemory($"Construiu {type} em {location.RegionName}");
+        mind.IdeaEngine.GenerateIdea($"Construção de {type}", new() { location.RegionName }, emotion, 0.8f);
+
+        if (emotion > 0.7f)
+            SacredSpace.SanctifyRegion(location.RegionName);
+    }
+
+    private static string ClassifyStructure(string purpose)
+    {
+        if (purpose.Contains("fé") || purpose.Contains("deus")) return "Templo";
+        if (purpose.Contains("memória") || purpose.Contains("história")) return "Monumento";
+        if (purpose.Contains("proteção")) return "Muro";
+        if (purpose.Contains("amor") || purpose.Contains("paz")) return "Casa";
+        return "Altar Ritual";
+    }
+
+    public static string DescribeAll()
+    {
+        if (BuiltStructures.Count == 0)
+            return "Nada foi construído ainda.";
+
+        var desc = new List<string>();
+        foreach (var s in BuiltStructures)
+        {
+            desc.Add($"[{s.Region}] - {s.Type} por {s.CreatedBy} (Motivo: {s.SymbolicPurpose})");
+        }
+        return string.Join("\n", desc);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/ConstructionEngineTests.cs
+++ b/tests/UltraWorldAI.Tests/ConstructionEngineTests.cs
@@ -1,0 +1,21 @@
+using UltraWorldAI;
+using UltraWorldAI.Territory;
+using Xunit;
+
+public class ConstructionEngineTests
+{
+    [Fact]
+    public void BuildStructureCreatesEntryAndSanctifiesWhenEmotional()
+    {
+        var builder = new Person("Construtor");
+        builder.Mind.Emotions.SetEmotion("happiness", 0.9f);
+
+        ConstructionEngine.BuildStructure(builder.Mind, builder.Location, "fé na comunidade");
+
+        Assert.Single(ConstructionEngine.BuiltStructures);
+        var structure = ConstructionEngine.BuiltStructures[0];
+        Assert.Equal("Templo", structure.Type);
+        Assert.True(SacredSpace.IsSacred(builder.Location.RegionName));
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `ConstructionEngine` for symbolic world building
- add tests covering new construction behavior

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6841dffc192083239581ac64f570079a