### PR TITLE
Implement DivineBeing religion module

### DIFF
--- a/src/UltraWorldAI/DivineBeing.cs
+++ b/src/UltraWorldAI/DivineBeing.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using UltraWorldAI.Territory;
+
+namespace UltraWorldAI
+{
+    public class DivineBeing
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Appearance { get; set; } = string.Empty;
+        public List<string> Domains { get; } = new();
+        public string Agenda { get; set; } = string.Empty;
+        public Dictionary<string, float> Traits { get; } = new();
+
+        public void Inspire(Mind mind)
+        {
+            mind.Beliefs.UpdateBelief($"fé em {Name}", 0.2f);
+            mind.Memory.AddMemory($"Sentiu a presença de {Name}", 0.6f, 0.9f, new() { "religião" }, "divino");
+        }
+
+        public void BlessRegion(string regionName)
+        {
+            SacredSpace.SanctifyRegion(regionName);
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/DivineBeingTests.cs
+++ b/tests/UltraWorldAI.Tests/DivineBeingTests.cs
@@ -1,0 +1,26 @@
+using UltraWorldAI;
+using UltraWorldAI.Territory;
+using Xunit;
+
+public class DivineBeingTests
+{
+    [Fact]
+    public void InspireAddsBeliefAndMemory()
+    {
+        var god = new DivineBeing { Name = "Aureon" };
+        var follower = new Person("Crente");
+
+        god.Inspire(follower.Mind);
+
+        Assert.Contains($"fé em {god.Name}", follower.Mind.Beliefs.Beliefs.Keys);
+        Assert.Contains(follower.Mind.Memory.Memories, m => m.Summary.Contains(god.Name));
+    }
+
+    [Fact]
+    public void BlessRegionMarksSacred()
+    {
+        var god = new DivineBeing { Name = "Aureon" };
+        god.BlessRegion("Templo Antigo");
+        Assert.True(SacredSpace.IsSacred("Templo Antigo"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `DivineBeing` for modular deities
- unit tests for DivineBeing behaviour

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6841e12560ac8323985d68eba7532264