### PR TITLE
Add DoctrineEngine for religious dogma generation

### DIFF
--- a/src/UltraWorldAI/Religion/DoctrineEngine.cs
+++ b/src/UltraWorldAI/Religion/DoctrineEngine.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion
+{
+    public class Doctrine
+    {
+        public string Title { get; set; } = string.Empty;
+        public string OriginGod { get; set; } = string.Empty;
+        public List<string> SacredRules { get; set; } = new();
+        public string TransmissionMethod { get; set; } = string.Empty;
+        public bool IsMutable { get; set; }
+        public List<string> KnownHeresies { get; } = new();
+    }
+
+    public static class DoctrineEngine
+    {
+        public static List<Doctrine> Doctrines { get; } = new();
+
+        public static Doctrine CreateDoctrine(DivineBeing god)
+        {
+            var doctrine = new Doctrine
+            {
+                Title = $"Caminho de {god.Name}",
+                OriginGod = god.Name,
+                IsMutable = god.Temperament == DivineTemperament.Dual,
+                TransmissionMethod = GetMethod(god.Domain),
+                SacredRules = GenerateRules(god)
+            };
+
+            Doctrines.Add(doctrine);
+            return doctrine;
+        }
+
+        private static string GetMethod(DivineDomain domain)
+        {
+            return domain switch
+            {
+                DivineDomain.Memoria => "tatuagem",
+                DivineDomain.Silencio => "gesto ritual",
+                DivineDomain.Tempo => "escultura em pedra",
+                _ => "oral"
+            };
+        }
+
+        private static List<string> GenerateRules(DivineBeing god)
+        {
+            var list = new List<string>();
+            if (god.Domain == DivineDomain.Sangue)
+            {
+                list.Add("Todo ciclo deve terminar em oferenda.");
+                list.Add("Nunca negar o clamor do corpo.");
+            }
+
+            if (god.Domain == DivineDomain.Memoria)
+            {
+                list.Add("Escreva os nomes dos mortos com lagrimas.");
+            }
+
+            if (god.Temperament == DivineTemperament.Vingativo)
+            {
+                list.Add("Nao perdoe o traidor. Nem em pensamento.");
+            }
+
+            return list;
+        }
+
+        public static void AddHeresy(Doctrine doctrine, string contradiction)
+        {
+            doctrine.KnownHeresies.Add(contradiction);
+        }
+
+        public static string DescribeDoctrine(Doctrine doctrine)
+        {
+            return $"\uD83D\uDCDC {doctrine.Title} – Transmissao: {doctrine.TransmissionMethod}\n" +
+                   $"Regras: {string.Join(" / ", doctrine.SacredRules)}\n" +
+                   $"Heresias conhecidas: {string.Join(" / ", doctrine.KnownHeresies)}";
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/DoctrineEngineTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrineEngineTests.cs
@@ -1,0 +1,28 @@
+using UltraWorldAI;
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class DoctrineEngineTests
+{
+    [Fact]
+    public void CreateDoctrineFromGodSetsTransmissionMethod()
+    {
+        var god = new DivineBeing { Name = "Apona", Domain = DivineDomain.Memoria };
+
+        var doctrine = DoctrineEngine.CreateDoctrine(god);
+
+        Assert.Equal("tatuagem", doctrine.TransmissionMethod);
+        Assert.Contains("Caminho de", doctrine.Title);
+    }
+
+    [Fact]
+    public void AddHeresyRegistersContradiction()
+    {
+        var god = new DivineBeing { Name = "Velar" };
+        var doctrine = DoctrineEngine.CreateDoctrine(god);
+
+        DoctrineEngine.AddHeresy(doctrine, "Negar o ritual");
+
+        Assert.Contains("Negar o ritual", doctrine.KnownHeresies);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DoctrineEngine` to create mutable doctrines and track heresies
- support description generation for doctrines
- add tests validating doctrine creation and heresy registration

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e724072c8323be566de71c5300c6