### PR TITLE
Add ProphecySystem with tests

### DIFF
--- a/src/UltraWorldAI/Religion/ProphecySystem.cs
+++ b/src/UltraWorldAI/Religion/ProphecySystem.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion
+{
+    public class Prophecy
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Trigger { get; set; } = string.Empty;
+        public string PredictedEvent { get; set; } = string.Empty;
+        public bool IsFulfilled { get; set; }
+        public bool IsCorrupted { get; set; }
+        public string Origin { get; set; } = string.Empty;
+        public string Transmission { get; set; } = string.Empty;
+
+        public string Describe()
+        {
+            var status = IsFulfilled ? "Cumprida" : IsCorrupted ? "Corrompida" : "Em aberto";
+            return $"\uD83D\uDD2E Profecia: {Title}\n" +
+                   $"Origem: {Origin} / Via: {Transmission}\n" +
+                   $"Gatilho: {Trigger}\n" +
+                   $"Evento previsto: {PredictedEvent}\n" +
+                   $"Status: {status}";
+        }
+    }
+
+    public static class ProphecySystem
+    {
+        private static readonly List<Prophecy> _prophecies = new();
+        public static IReadOnlyList<Prophecy> AllProphecies => _prophecies;
+
+        public static Prophecy Create(string title, string origin, string transmission, string trigger, string prediction)
+        {
+            var prophecy = new Prophecy
+            {
+                Title = title,
+                Origin = origin,
+                Transmission = transmission,
+                Trigger = trigger,
+                PredictedEvent = prediction
+            };
+
+            _prophecies.Add(prophecy);
+            return prophecy;
+        }
+
+        public static void Fulfill(string title)
+        {
+            var p = _prophecies.Find(prophecy => prophecy.Title == title);
+            if (p != null) p.IsFulfilled = true;
+        }
+
+        public static void Corrupt(string title)
+        {
+            var p = _prophecies.Find(prophecy => prophecy.Title == title);
+            if (p != null) p.IsCorrupted = true;
+        }
+
+        public static string DescribeAll()
+        {
+            if (_prophecies.Count == 0) return "Nenhuma profecia conhecida.";
+            return string.Join("\n\n", _prophecies.ConvertAll(p => p.Describe()));
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
@@ -1,0 +1,34 @@
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class ProphecySystemTests
+{
+    [Fact]
+    public void CreateAddsProphecyToList()
+    {
+        var prophecy = ProphecySystem.Create("Queda do Sol", "Oraculo", "sonho", "Eclipse total", "Sol desaparecera");
+
+        Assert.Contains(prophecy, ProphecySystem.AllProphecies);
+        Assert.Equal("Queda do Sol", prophecy.Title);
+    }
+
+    [Fact]
+    public void FulfillMarksProphecy()
+    {
+        var prophecy = ProphecySystem.Create("Chuva Vermelha", "Sacerdotisa", "sangue", "Lua cheia", "Chovera sangue");
+
+        ProphecySystem.Fulfill("Chuva Vermelha");
+
+        Assert.True(prophecy.IsFulfilled);
+    }
+
+    [Fact]
+    public void CorruptMarksProphecy()
+    {
+        var prophecy = ProphecySystem.Create("Mentira", "Culto", "sussurro", "Sinal", "Nada ocorre");
+
+        ProphecySystem.Corrupt("Mentira");
+
+        Assert.True(prophecy.IsCorrupted);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Prophecy system for religious visions
- test prophecy creation and state changes

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841e834f19083239ca5d85940fbc2b8