### PR TITLE
Implement CultSplit system for religious schisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **CalendarBuilder** cria calendários culturais simbólicos para cada cultura.
 - **PhilosophicalIntegrity** avalia a coerência entre ideias geradas.
 - **InternalDialectics** coloca ideias em confronto, permitindo sínteses ou reforço.
+- **DivineBeing** permite criar deuses com domínio e temperamento.
+- **FaithSystem** acompanha devoção, dúvida e heresia.
+- **DoctrineEngine** cria dogmas e textos sagrados.
+- **ProphecySystem** registra e cumpre profecias.
+- **CultSplit** gera cismas e novos cultos a partir de doutrinas.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **xUnit tests** verificam memórias e resolução de contradições.
 

--- a/src/UltraWorldAI/Religion/CultSplit.cs
+++ b/src/UltraWorldAI/Religion/CultSplit.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Religion;
+
+public class Cult
+{
+    public string Name { get; set; } = string.Empty;
+    public string OriginDoctrine { get; set; } = string.Empty;
+    public List<string> NewDogmas { get; set; } = new();
+    public bool IsPersecuted { get; set; }
+    public string FounderID { get; set; } = string.Empty;
+    public string ReasonForSplit { get; set; } = string.Empty;
+}
+
+public static class CultSplit
+{
+    public static List<Cult> AllCults { get; } = new();
+
+    public static Cult CreateCultFromDoctrine(Doctrine original, string founderID, string reason)
+    {
+        var cult = new Cult
+        {
+            Name = $"Voz de {founderID}",
+            OriginDoctrine = original.Title,
+            FounderID = founderID,
+            ReasonForSplit = reason,
+            NewDogmas = original.SacredRules
+                .Where(r => !r.Contains("proibido"))
+                .Select(r => $"Revisado: {r}")
+                .ToList()
+        };
+
+        if (!original.IsMutable)
+        {
+            original.KnownHeresies.Add($"Cisma iniciado por {founderID}");
+        }
+
+        AllCults.Add(cult);
+        return cult;
+    }
+
+    public static void PersecuteCult(Cult cult)
+    {
+        cult.IsPersecuted = true;
+        cult.NewDogmas.Add("Sofremos por fé – e renascemos na dor.");
+    }
+
+    public static string DescribeCult(Cult cult)
+    {
+        return $"\uD83D\uDD94 Culto: {cult.Name}\nFundador: {cult.FounderID}\nOrigem: {cult.OriginDoctrine}\n" +
+               $"Motivo do Cisma: {cult.ReasonForSplit}\nPerseguido: {cult.IsPersecuted}\n" +
+               $"Dogmas: {string.Join(" / ", cult.NewDogmas)}";
+    }
+
+    public static string ListAllCults()
+    {
+        if (AllCults.Count == 0) return "Nenhum culto ou heresia registrada.";
+        return string.Join("\n\n", AllCults.Select(DescribeCult));
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/CultSplitTests.cs
+++ b/tests/UltraWorldAI.Tests/CultSplitTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class CultSplitTests
+{
+    [Fact]
+    public void CreateCultFromDoctrineRegistersCult()
+    {
+        var doctrine = new Doctrine
+        {
+            Title = "Origem",
+            SacredRules = new List<string> { "Seguir a luz", "proibido mentir" },
+            IsMutable = false
+        };
+
+        var cult = CultSplit.CreateCultFromDoctrine(doctrine, "Ana", "discordância");
+
+        Assert.Contains(cult, CultSplit.AllCults);
+        Assert.DoesNotContain(cult.NewDogmas, d => d.Contains("proibido"));
+        Assert.Contains(doctrine.KnownHeresies, h => h.Contains("Ana"));
+    }
+
+    [Fact]
+    public void PersecuteCultMarksCult()
+    {
+        var cult = new Cult { Name = "Test", OriginDoctrine = "Base" };
+
+        CultSplit.PersecuteCult(cult);
+
+        Assert.True(cult.IsPersecuted);
+        Assert.Contains(cult.NewDogmas, d => d.Contains("Sofremos"));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `CultSplit` class for handling cult splits
- add unit tests for the CultSplit features
- document religion modules in README

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6841eb3a55688323b1842b960e712f32