### PR TITLE
Clamp belief conviction when resolving contradictions

### DIFF
--- a/src/UltraWorldAI/BeliefArchitecture.cs
+++ b/src/UltraWorldAI/BeliefArchitecture.cs
@@ -66,8 +66,14 @@ namespace UltraWorldAI
                 {
                     conflict.TriggerContradiction("crença", $"{a.Statement} ↔ {b.Statement}");
 
-                    if (a.Conviction < b.Conviction) a.Conviction -= 0.1f;
-                    else b.Conviction -= 0.1f;
+                    if (a.Conviction < b.Conviction)
+                    {
+                        a.Conviction = Math.Max(0f, a.Conviction - 0.1f);
+                    }
+                    else
+                    {
+                        b.Conviction = Math.Max(0f, b.Conviction - 0.1f);
+                    }
                 }
             }
 

--- a/tests/UltraWorldAI.Tests/BeliefArchitectureTests.cs
+++ b/tests/UltraWorldAI.Tests/BeliefArchitectureTests.cs
@@ -30,4 +30,17 @@ public class BeliefArchitectureTests
         Assert.True(weakened < weakBefore);
         Assert.True(person.Mind.Conflict.HasActiveContradictions());
     }
+
+    [Fact]
+    public void ResolveContradictionsDoesNotMakeConvictionsNegative()
+    {
+        var person = new Person("Philo");
+        var arch = person.Mind.DynamicBeliefs;
+        arch.AddBelief("Sempre fazer o bem", 0.2f, "ensinamento", "hope");
+        arch.AddBelief("Nunca fazer o bem", 0.9f, "opressor", "fear");
+
+        arch.ResolveContradictions(person.Mind.Conflict, person.Mind.Emotions);
+
+        Assert.DoesNotContain(arch.Beliefs, b => b.Conviction < 0f);
+    }
 }


### PR DESCRIPTION
## Summary
- prevent `BeliefArchitecture` from producing negative conviction values
- add regression test ensuring belief convictions stay non-negative

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6841edb836388323b9e2d8e84ee5557a