### PR TITLE
Enhance memory system with emotion retrieval

### DIFF
--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -33,6 +33,11 @@ namespace UltraWorldAI
         public float EmotionalCharge { get; set; }
 
         /// <summary>
+        /// Optional label describing the dominant emotion.
+        /// </summary>
+        public string Emotion { get; set; } = string.Empty;
+
+        /// <summary>
         /// Keywords that help relate this memory to other concepts.
         /// </summary>
         public List<string> Keywords { get; set; }
@@ -67,7 +72,7 @@ namespace UltraWorldAI
         /// <param name="emotionalCharge">Associated emotional valence.</param>
         /// <param name="keywords">Optional keywords for retrieval.</param>
         /// <param name="source">Source of the experience.</param>
-        public void AddMemory(string summary, float intensity = 0.5f, float emotionalCharge = 0.0f, List<string>? keywords = null, string source = "self")
+        public void AddMemory(string summary, float intensity = 0.5f, float emotionalCharge = 0.0f, List<string>? keywords = null, string source = "self", string emotion = "")
         {
             if (Memories.Count >= AISettings.MaxMemories)
             {
@@ -80,7 +85,8 @@ namespace UltraWorldAI
                 Intensity = Math.Clamp(intensity, 0f, 1f),
                 EmotionalCharge = Math.Clamp(emotionalCharge, -1f, 1f),
                 Keywords = keywords ?? new List<string>(),
-                Source = source
+                Source = source,
+                Emotion = emotion
             });
             Memories = Memories.OrderByDescending(m => m.Date).ToList();
         }
@@ -229,6 +235,33 @@ namespace UltraWorldAI
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Retrieves memories tagged with a specific emotion label.
+        /// </summary>
+        public List<Memory> RetrieveMemoriesByEmotion(string emotion, int count = 5)
+        {
+            var results = Memories
+                .Where(m => string.Equals(m.Emotion, emotion, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(m => m.Intensity)
+                .Take(count)
+                .ToList();
+
+            foreach (var mem in results)
+            {
+                mem.Intensity = Math.Min(1f, mem.Intensity + 0.05f);
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Returns the most intense memory or null if none exist.
+        /// </summary>
+        public Memory? GetMostIntenseMemory()
+        {
+            return Memories.OrderByDescending(m => m.Intensity).FirstOrDefault();
         }
     }
 }

--- a/tests/UltraWorldAI.Tests/MemoryTests.cs
+++ b/tests/UltraWorldAI.Tests/MemoryTests.cs
@@ -22,4 +22,31 @@ public class MemoryTests
 
         Assert.Equal("emocional", result[0].Summary);
     }
+
+    [Fact]
+    public void RetrieveMemoriesByEmotionFiltersCorrectly()
+    {
+        var memSys = new MemorySystem();
+        memSys.AddMemory("tristeza", 0.6f, -0.5f, null, "self", "sorrow");
+        memSys.AddMemory("alegria", 0.7f, 0.8f, null, "self", "happiness");
+        memSys.AddMemory("pavor", 0.9f, -0.9f, null, "self", "fear");
+
+        var results = memSys.RetrieveMemoriesByEmotion("fear", 2);
+
+        Assert.Single(results);
+        Assert.Equal("pavor", results[0].Summary);
+    }
+
+    [Fact]
+    public void GetMostIntenseMemoryReturnsHighestIntensity()
+    {
+        var memSys = new MemorySystem();
+        memSys.AddMemory("fraco", 0.1f);
+        memSys.AddMemory("forte", 0.9f);
+
+        var top = memSys.GetMostIntenseMemory();
+
+        Assert.NotNull(top);
+        Assert.Equal("forte", top!.Summary);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `Memory` with new `Emotion` field
- allow specifying emotion when adding memories
- add methods to get most intense memories and filter by emotion
- test new functionality

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6841effd74448323a76b2c1799e9fc99