### PR TITLE
Add imaginative technology creation

### DIFF
--- a/src/UltraWorldAI/Imagination/ConceptualTech.cs
+++ b/src/UltraWorldAI/Imagination/ConceptualTech.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Discovery
+{
+    public class ConceptualTech
+    {
+        public string Name { get; set; } = string.Empty;
+        public string CreatedBy { get; set; } = string.Empty;
+        public List<string> CombinedConcepts { get; set; } = new();
+        public string HypotheticalFunction { get; set; } = string.Empty;
+        public bool IsFunctional { get; set; }
+        public string Complexity { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+    }
+}

--- a/src/UltraWorldAI/Imagination/DiscoveryHistory.cs
+++ b/src/UltraWorldAI/Imagination/DiscoveryHistory.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Discovery
+{
+    public class DiscoveryEvent
+    {
+        public string DiscoveryName { get; set; } = string.Empty;
+        public string CreatedBy { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string OriginEmotion { get; set; } = string.Empty;
+        public string Context { get; set; } = string.Empty;
+        public DateTime Date { get; set; }
+    }
+
+    public static class DiscoveryHistory
+    {
+        public static List<DiscoveryEvent> Log { get; } = new();
+
+        public static void Register(string name, string by, string type, string emotion, string context)
+        {
+            Log.Add(new DiscoveryEvent
+            {
+                DiscoveryName = name,
+                CreatedBy = by,
+                Type = type,
+                OriginEmotion = emotion,
+                Context = context,
+                Date = DateTime.Now
+            });
+        }
+
+        public static string DescribeAll()
+        {
+            if (Log.Count == 0) return "Nada foi registrado na história do saber.";
+            return string.Join("\n\n", Log.ConvertAll(e =>
+                $"📚 {e.DiscoveryName} ({e.Type})\nPor: {e.CreatedBy} em {e.Date.ToShortDateString()}\n" +
+                $"Motivo emocional: {e.OriginEmotion}\nContexto: {e.Context}"));
+        }
+    }
+}

--- a/src/UltraWorldAI/Imagination/TechCreator.cs
+++ b/src/UltraWorldAI/Imagination/TechCreator.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Discovery
+{
+    public static class TechCreator
+    {
+        public static List<ConceptualTech> TechPool { get; } = new();
+
+        public static ConceptualTech CreateTech(string creator, List<string> concepts)
+        {
+            var combined = string.Join("-", concepts.OrderBy(c => c));
+            string name = $"Tec-{Math.Abs(combined.GetHashCode() % 99999)}";
+            string function = DeriveFunction(concepts);
+            string category = ClassifyCategory(concepts);
+            string complexity = ClassifyComplexity(concepts);
+
+            var tech = new ConceptualTech
+            {
+                Name = name,
+                CreatedBy = creator,
+                CombinedConcepts = concepts,
+                HypotheticalFunction = function,
+                IsFunctional = new Random().NextDouble() > 0.15,
+                Complexity = complexity,
+                Category = category
+            };
+
+            TechPool.Add(tech);
+            return tech;
+        }
+
+        private static string DeriveFunction(List<string> concepts)
+        {
+            if (concepts.Contains("som") && concepts.Contains("memória"))
+                return "Armazena vozes perdidas em pedra.";
+            if (concepts.Contains("fogo") && concepts.Contains("ponta"))
+                return "Cria luz cortante para abrir caminho.";
+            if (concepts.Contains("tempo") && concepts.Contains("sombra"))
+                return "Marca a passagem dos dias em forma viva.";
+            return $"Combinação criativa: {string.Join(" + ", concepts)}";
+        }
+
+        private static string ClassifyComplexity(List<string> concepts)
+        {
+            return concepts.Count switch
+            {
+                <= 2 => "Simples",
+                3 => "Média",
+                4 => "Avançada",
+                _ => "Alienígena"
+            };
+        }
+
+        private static string ClassifyCategory(List<string> concepts)
+        {
+            if (concepts.Contains("som") || concepts.Contains("imagem")) return "Objeto Simbólico";
+            if (concepts.Contains("fogo") || concepts.Contains("metal")) return "Ferramenta";
+            if (concepts.Contains("tempo") || concepts.Contains("memória")) return "Estrutura";
+            return "Invenção Desconhecida";
+        }
+
+        public static string Describe(ConceptualTech t)
+        {
+            return $"🛠️ {t.Name} ({t.Category}, {t.Complexity})\nPor: {t.CreatedBy}\n" +
+                   $"Conceitos: {string.Join(", ", t.CombinedConcepts)}\nFunção: {t.HypotheticalFunction}\n" +
+                   $"Estado: {(t.IsFunctional ? "✅ Funciona" : "❌ Não funcional")}";
+        }
+
+        public static string ListAll()
+        {
+            if (TechPool.Count == 0) return "Nenhuma tecnologia criada ainda.";
+            return string.Join("\n\n", TechPool.ConvertAll(Describe));
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/DiscoveryHistoryTests.cs
+++ b/tests/UltraWorldAI.Tests/DiscoveryHistoryTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Discovery;
+using Xunit;
+
+public class DiscoveryHistoryTests
+{
+    [Fact]
+    public void RegisterAddsEventToLog()
+    {
+        DiscoveryHistory.Log.Clear();
+        DiscoveryHistory.Register("Fogo Vivo", "IA", "Tecnologia", "curiosidade", "teste");
+        Assert.Single(DiscoveryHistory.Log);
+        var output = DiscoveryHistory.DescribeAll();
+        Assert.Contains("Fogo Vivo", output);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechCreatorTests.cs
+++ b/tests/UltraWorldAI.Tests/TechCreatorTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using UltraWorldAI.Discovery;
+using Xunit;
+
+public class TechCreatorTests
+{
+    [Fact]
+    public void CreateTechStoresInPool()
+    {
+        TechCreator.TechPool.Clear();
+        var tech = TechCreator.CreateTech("IA", new List<string> { "fogo", "ponta" });
+        Assert.Single(TechCreator.TechPool);
+        Assert.Contains("fogo", tech.CombinedConcepts);
+        Assert.NotEqual(string.Empty, tech.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ConceptualTech` record and `TechCreator` for creating imaginary technology
- add `DiscoveryHistory` to keep a log of inventions
- test creating technology and registering discoveries

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f65c85b88323b3276177d66321e4