### PR TITLE
Add world impact and technology intent systems

### DIFF
--- a/src/UltraWorldAI/Imagination/TechCreator.cs
+++ b/src/UltraWorldAI/Imagination/TechCreator.cs
@@ -8,20 +8,21 @@ namespace UltraWorldAI.Discovery
     {
         public static List<ConceptualTech> TechPool { get; } = new();
 
-        public static ConceptualTech CreateTech(string creator, List<string> concepts)
+        public static ConceptualTech CreateTech(string creator, List<string> concepts, string emotion = "", string philosophy = "")
         {
             var combined = string.Join("-", concepts.OrderBy(c => c));
             string name = $"Tec-{Math.Abs(combined.GetHashCode() % 99999)}";
             string function = DeriveFunction(concepts);
             string category = ClassifyCategory(concepts);
             string complexity = ClassifyComplexity(concepts);
+            string intent = TechIntentSystem.InferPurpose(concepts, emotion, philosophy);
 
             var tech = new ConceptualTech
             {
                 Name = name,
                 CreatedBy = creator,
                 CombinedConcepts = concepts,
-                HypotheticalFunction = function,
+                HypotheticalFunction = $"{function} (Intenção: {intent})",
                 IsFunctional = new Random().NextDouble() > 0.15,
                 Complexity = complexity,
                 Category = category

--- a/src/UltraWorldAI/Society/TechCivilizationStyles.cs
+++ b/src/UltraWorldAI/Society/TechCivilizationStyles.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Society;
+
+public class CivilizationStyle
+{
+    public string Name { get; set; } = string.Empty;
+    public string BasedOnTech { get; set; } = string.Empty;
+    public List<string> Traits { get; set; } = new();
+    public string GovernmentModel { get; set; } = string.Empty;
+    public string CulturalTheme { get; set; } = string.Empty;
+}
+
+public static class TechCivilizationStyles
+{
+    public static List<CivilizationStyle> Styles { get; } = new();
+
+    public static CivilizationStyle CreateStyle(string tech, string creator)
+    {
+        string gov = tech switch
+        {
+            var t when t.Contains("controle") => "Tecnocracia Centralizada",
+            var t when t.Contains("ritual") => "Magocracia Espiritual",
+            var t when t.Contains("arma") => "Feudalismo Militar",
+            var t when t.Contains("rede") => "Tecnodemocracia Colaborativa",
+            _ => "Tribo Simbolica Autonoma"
+        };
+
+        string theme = tech switch
+        {
+            var t when t.Contains("sangue") => "Cultura de Sacrificio",
+            var t when t.Contains("memoria") => "Cultura Arquivista",
+            var t when t.Contains("som") => "Cultura Musical",
+            _ => "Cultura Adaptativa"
+        };
+
+        var traits = new List<string> { $"Tecnologia dominante: {tech}", $"Sistema: {gov}", $"Tema: {theme}" };
+
+        var style = new CivilizationStyle
+        {
+            Name = $"Civilizacao de {creator}",
+            BasedOnTech = tech,
+            Traits = traits,
+            GovernmentModel = gov,
+            CulturalTheme = theme
+        };
+
+        Styles.Add(style);
+        return style;
+    }
+
+    public static string ListAll()
+    {
+        if (Styles.Count == 0) return "Nenhum estilo civilizacional foi criado.";
+        return string.Join("\n\n", Styles.ConvertAll(c =>
+            $"\uD83C\uDFDB\uFE0F {c.Name}\nTecnologia: {c.BasedOnTech}\nGoverno: {c.GovernmentModel}\nCultura: {c.CulturalTheme}"));
+    }
+}

--- a/src/UltraWorldAI/TechIntentSystem.cs
+++ b/src/UltraWorldAI/TechIntentSystem.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Discovery;
+
+public static class TechIntentSystem
+{
+    public static string InferPurpose(List<string> concepts, string emotion, string philosophy)
+    {
+        if (emotion.Contains("dor")) return "Causar dor ou marcar trauma";
+        if (emotion.Contains("compaixao")) return "Curar ou preservar";
+        if (philosophy.Contains("controle")) return "Dominar fenomenos ou mentes";
+        if (concepts.Contains("imagem") || concepts.Contains("som")) return "Expressar arte ou registrar";
+        if (concepts.Contains("sangue") && emotion.Contains("furia")) return "Destruicao ritual";
+        return "Proposito emergente";
+    }
+}

--- a/src/UltraWorldAI/TechLoreSystem.cs
+++ b/src/UltraWorldAI/TechLoreSystem.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace UltraWorldAI.Discovery;
+
+public class TechLore
+{
+    public string TechName { get; set; } = string.Empty;
+    public string CreatedBy { get; set; } = string.Empty;
+    public string MomentOfCreation { get; set; } = string.Empty;
+    public string FirstUse { get; set; } = string.Empty;
+    public string CulturalReaction { get; set; } = string.Empty;
+}
+
+public static class TechLoreSystem
+{
+    private static readonly string[] CreationMoments =
+    {
+        "um colapso espiritual", "uma tempestade simbolica",
+        "um ritual de fogo", "um grito silencioso", "um sonho lucido"
+    };
+
+    private static readonly string[] Uses =
+    {
+        "para salvar uma crianca", "para conquistar um templo",
+        "num duelo sagrado", "num pacto entre racas", "num funeral coletivo"
+    };
+
+    private static readonly string[] Reactions =
+    {
+        "foi adorada por geracoes", "foi queimada como heresia",
+        "se tornou tabu em cinco culturas", "virou um simbolo de paz",
+        "foi esquecida e depois redescoberta"
+    };
+
+    private static readonly Random Rng = new();
+
+    public static string GenerateLore(ConceptualTech tech)
+    {
+        return $"\u2699 Lenda de {tech.Name}:\n" +
+               $"Criada por {tech.CreatedBy} durante {RandomPick(CreationMoments)}.\n" +
+               $"Primeiro uso: {RandomPick(Uses)}.\n" +
+               $"Reacao cultural: {RandomPick(Reactions)}";
+    }
+
+    private static string RandomPick(string[] options) => options[Rng.Next(options.Length)];
+}

--- a/src/UltraWorldAI/TechModularity.cs
+++ b/src/UltraWorldAI/TechModularity.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Discovery;
+
+public class ModularTech
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Modules { get; } = new();
+    public string ResultFunction { get; set; } = string.Empty;
+}
+
+public static class TechModularity
+{
+    public static ModularTech CombineTechs(string newName, List<ConceptualTech> techs)
+    {
+        var modules = new List<string>();
+        var finalFunction = string.Empty;
+
+        foreach (var t in techs)
+        {
+            modules.Add(t.Name);
+            finalFunction += $"[{t.HypotheticalFunction}] ";
+        }
+
+        return new ModularTech
+        {
+            Name = newName,
+            Modules = modules,
+            ResultFunction = finalFunction.Trim()
+        };
+    }
+}

--- a/src/UltraWorldAI/World/WorldImpactSystem.cs
+++ b/src/UltraWorldAI/World/WorldImpactSystem.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class WorldImpact
+{
+    public string TechName { get; set; } = string.Empty;
+    public string Region { get; set; } = string.Empty;
+    public string Effect { get; set; } = string.Empty;
+    public string EnvironmentalSymbol { get; set; } = string.Empty;
+}
+
+public static class WorldImpactSystem
+{
+    public static List<WorldImpact> Impacts { get; } = new();
+
+    public static void ApplyImpact(string techName, string region, string type)
+    {
+        string effect = type switch
+        {
+            "terra" => "O solo se tornou fertil/saturado",
+            "clima" => "O clima local se aqueceu/resfriou",
+            "cultura" => "Crencas e comportamentos mudaram",
+            "fluxo" => "Rotas comerciais ou migratorias foram alteradas",
+            _ => "Mudanca simbolica nao especificada"
+        };
+
+        Impacts.Add(new WorldImpact
+        {
+            TechName = techName,
+            Region = region,
+            Effect = effect,
+            EnvironmentalSymbol = $"Marca simbolica de {techName}"
+        });
+    }
+
+    public static string ListAll()
+    {
+        if (Impacts.Count == 0) return "Nenhuma tecnologia afetou o mundo ainda.";
+        return string.Join("\n\n", Impacts.ConvertAll(i =>
+            $"\uD83C\uDF0D {i.TechName} alterou {i.Region}\nEfeito: {i.Effect}\nSimbolo: {i.EnvironmentalSymbol}"));
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechCivilizationStylesTests.cs
+++ b/tests/UltraWorldAI.Tests/TechCivilizationStylesTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.Society;
+using Xunit;
+
+public class TechCivilizationStylesTests
+{
+    [Fact]
+    public void CreateStyleAddsStyle()
+    {
+        TechCivilizationStyles.Styles.Clear();
+        var style = TechCivilizationStyles.CreateStyle("controle", "IA");
+        Assert.Single(TechCivilizationStyles.Styles);
+        Assert.Equal("Civilizacao de IA", style.Name);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechIntentSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/TechIntentSystemTests.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UltraWorldAI.Discovery;
+using Xunit;
+
+public class TechIntentSystemTests
+{
+    [Fact]
+    public void InferPurposeRecognizesArt()
+    {
+        var concepts = new List<string> { "imagem", "som" };
+        var intent = TechIntentSystem.InferPurpose(concepts, "", "");
+        Assert.Equal("Expressar arte ou registrar", intent);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechLoreSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/TechLoreSystemTests.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using UltraWorldAI.Discovery;
+using Xunit;
+
+public class TechLoreSystemTests
+{
+    [Fact]
+    public void GenerateLoreReturnsText()
+    {
+        TechCreator.TechPool.Clear();
+        var tech = TechCreator.CreateTech("X", new List<string> { "fogo" });
+        var lore = TechLoreSystem.GenerateLore(tech);
+        Assert.Contains("Lenda de", lore);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechModularityTests.cs
+++ b/tests/UltraWorldAI.Tests/TechModularityTests.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using UltraWorldAI.Discovery;
+using Xunit;
+
+public class TechModularityTests
+{
+    [Fact]
+    public void CombineTechsAggregatesModules()
+    {
+        TechCreator.TechPool.Clear();
+        var t1 = TechCreator.CreateTech("A", new List<string> { "fogo" });
+        var t2 = TechCreator.CreateTech("A", new List<string> { "som" });
+        var modular = TechModularity.CombineTechs("Mix", new List<ConceptualTech> { t1, t2 });
+
+        Assert.Equal(2, modular.Modules.Count);
+        Assert.Contains(t1.Name, modular.Modules);
+    }
+}

--- a/tests/UltraWorldAI.Tests/WorldImpactSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/WorldImpactSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.World;
+using Xunit;
+
+public class WorldImpactSystemTests
+{
+    [Fact]
+    public void ApplyImpactStoresRecord()
+    {
+        WorldImpactSystem.Impacts.Clear();
+        WorldImpactSystem.ApplyImpact("TecA", "Regiao", "clima");
+
+        Assert.Single(WorldImpactSystem.Impacts);
+        Assert.Equal("TecA", WorldImpactSystem.Impacts[0].TechName);
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `TechIntentSystem` and hook into `TechCreator`
- add modular tech combinations via `TechModularity`
- generate lore with `TechLoreSystem`
- track world changes with `WorldImpactSystem`
- create civilization styles with `TechCivilizationStyles`
- add corresponding unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f9af9ba48323a2d4cb136e273daf