### PR TITLE
Add tech timeline and conflict systems

### DIFF
--- a/src/UltraWorldAI/TechCivilizationConflict.cs
+++ b/src/UltraWorldAI/TechCivilizationConflict.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Conflict;
+
+public class CivilizationalWar
+{
+    public string CultureA { get; set; } = string.Empty;
+    public string CultureB { get; set; } = string.Empty;
+    public string TechConflict { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public bool IsResolved { get; set; }
+}
+
+public static class TechCivilizationConflict
+{
+    private static readonly Random Rng = new();
+    public static List<CivilizationalWar> Wars { get; } = new();
+
+    public static CivilizationalWar Declare(string a, string b, string tech, string reason)
+    {
+        var war = new CivilizationalWar
+        {
+            CultureA = a,
+            CultureB = b,
+            TechConflict = tech,
+            Reason = reason,
+            IsResolved = false
+        };
+
+        Wars.Add(war);
+        return war;
+    }
+
+    public static void Resolve(CivilizationalWar war)
+    {
+        war.Outcome = Rng.NextDouble() > 0.5
+            ? $"{war.CultureA} imp\u00f4s sua vis\u00e3o tecnol\u00f3gica."
+            : $"{war.CultureB} venceu e suprimiu o estilo rival.";
+
+        war.IsResolved = true;
+    }
+
+    public static string ListAll()
+    {
+        if (Wars.Count == 0) return "Nenhuma guerra civilizacional registrada.";
+        return string.Join("\n\n", Wars.ConvertAll(w =>
+            $"\u2694\uFE0F {w.CultureA} vs {w.CultureB}\nConflito: {w.TechConflict}\n" +
+            $"Motivo: {w.Reason}\nResultado: {(w.IsResolved ? w.Outcome : "Em andamento")}"));
+    }
+}

--- a/src/UltraWorldAI/TechMindInfluence.cs
+++ b/src/UltraWorldAI/TechMindInfluence.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Mental;
+
+public static class TechMindInfluence
+{
+    public static Dictionary<string, List<string>> CognitiveTraits { get; } = new();
+
+    public static void ApplyTechInfluence(string brainID, string style)
+    {
+        List<string> traits = style switch
+        {
+            string s when s.Contains("Tecnocracia") => new() { "l\u00f3gica fria", "efici\u00eancia", "an\u00e1lise cont\u00ednua" },
+            string s when s.Contains("Magocracia") => new() { "intui\u00e7\u00e3o simb\u00f3lica", "ciclos lunares", "mem\u00f3ria ritual" },
+            string s when s.Contains("Feudalismo") => new() { "honra", "hierarquia", "resposta direta" },
+            string s when s.Contains("Rede") => new() { "colabora\u00e7\u00e3o", "autonomia", "resolu\u00e7\u00e3o emergente" },
+            _ => new() { "ancestralidade", "preserva\u00e7\u00e3o", "sil\u00eancio emocional" }
+        };
+
+        CognitiveTraits[brainID] = traits;
+    }
+
+    public static string Describe(string brainID)
+    {
+        return CognitiveTraits.ContainsKey(brainID)
+            ? $"\uD83E\uDD16 Tra\u00e7os mentais de {brainID}: {string.Join(", ", CognitiveTraits[brainID])}"
+            : "Nenhuma influ\u00eancia tecnol\u00f3gica aplicada ainda.";
+    }
+}

--- a/src/UltraWorldAI/TechModularity.cs
+++ b/src/UltraWorldAI/TechModularity.cs
@@ -22,11 +22,12 @@ public static class TechModularity
             finalFunction += $"[{t.HypotheticalFunction}] ";
         }
 
-        return new ModularTech
+        var modular = new ModularTech
         {
             Name = newName,
-            Modules = modules,
             ResultFunction = finalFunction.Trim()
         };
+        modular.Modules.AddRange(modules);
+        return modular;
     }
 }

--- a/src/UltraWorldAI/TechTimelineSystem.cs
+++ b/src/UltraWorldAI/TechTimelineSystem.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.History;
+
+public class TechEra
+{
+    public string Name { get; set; } = string.Empty;
+    public string TriggerTech { get; set; } = string.Empty;
+    public DateTime Start { get; set; }
+    public List<string> Characteristics { get; set; } = new();
+}
+
+public static class TechTimelineSystem
+{
+    public static List<TechEra> Eras { get; } = new();
+
+    public static void CreateEra(string tech, string style)
+    {
+        string name = $"Era de {tech}";
+        var traits = new List<string>
+        {
+            $"Estilo dominante: {style}",
+            $"Funda\u00e7\u00e3o: {tech}",
+            "Transi\u00e7\u00e3o marcada por: ruptura ou ades\u00e3o tecnol\u00f3gica"
+        };
+
+        Eras.Add(new TechEra
+        {
+            Name = name,
+            TriggerTech = tech,
+            Start = DateTime.Now,
+            Characteristics = traits
+        });
+    }
+
+    public static string DescribeAll()
+    {
+        if (Eras.Count == 0) return "Nenhuma era tecnol\u00f3gica registrada ainda.";
+        return string.Join("\n\n", Eras.ConvertAll(e =>
+            $"\uD83D\uDCDC {e.Name}\nIniciada por: {e.TriggerTech} em {e.Start.ToShortDateString()}\n" +
+            $"Caracter\u00edsticas: {string.Join(", ", e.Characteristics)}"));
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechCivilizationConflictTests.cs
+++ b/tests/UltraWorldAI.Tests/TechCivilizationConflictTests.cs
@@ -1,0 +1,22 @@
+using UltraWorldAI.Conflict;
+using Xunit;
+
+public class TechCivilizationConflictTests
+{
+    [Fact]
+    public void DeclareAddsWar()
+    {
+        TechCivilizationConflict.Wars.Clear();
+        var war = TechCivilizationConflict.Declare("A", "B", "laser", "poder");
+        Assert.Contains(war, TechCivilizationConflict.Wars);
+    }
+
+    [Fact]
+    public void ResolveSetsOutcome()
+    {
+        var war = TechCivilizationConflict.Declare("A", "B", "laser", "poder");
+        TechCivilizationConflict.Resolve(war);
+        Assert.True(war.IsResolved);
+        Assert.False(string.IsNullOrEmpty(war.Outcome));
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechMindInfluenceTests.cs
+++ b/tests/UltraWorldAI.Tests/TechMindInfluenceTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Mental;
+using Xunit;
+
+public class TechMindInfluenceTests
+{
+    [Fact]
+    public void ApplyTechInfluenceStoresTraits()
+    {
+        TechMindInfluence.CognitiveTraits.Clear();
+        TechMindInfluence.ApplyTechInfluence("id", "Tecnocracia Alfa");
+        Assert.True(TechMindInfluence.CognitiveTraits.ContainsKey("id"));
+        string desc = TechMindInfluence.Describe("id");
+        Assert.Contains("Tra\u00e7os mentais", desc);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechTimelineSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/TechTimelineSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.History;
+using Xunit;
+
+public class TechTimelineSystemTests
+{
+    [Fact]
+    public void CreateEraAddsEra()
+    {
+        TechTimelineSystem.Eras.Clear();
+        TechTimelineSystem.CreateEra("fogo", "tribal");
+        Assert.Single(TechTimelineSystem.Eras);
+        string desc = TechTimelineSystem.DescribeAll();
+        Assert.Contains("Era de fogo", desc);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TechTimelineSystem` for tracking technology-driven eras
- add `TechCivilizationConflict` to model clashes over technology
- introduce `TechMindInfluence` describing how tech styles shape cognition
- fix initialization bug in `TechModularity.CombineTechs`
- test the new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841fac40a748323a142f623ae5cbdf1