### PR TITLE
Add world generation systems

### DIFF
--- a/src/UltraWorldAI/World/EnvironmentalFluxSystem.cs
+++ b/src/UltraWorldAI/World/EnvironmentalFluxSystem.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace UltraWorldAI.World;
+
+public static class EnvironmentalFluxSystem
+{
+    public static void FluxBiome(WorldRegion region, string trigger)
+    {
+        string oldBiome = region.Biome;
+        string newBiome = trigger switch
+        {
+            "guerra" => "Terra Queimada",
+            "milagre" => "Solo Sagrado",
+            "colapso" => "Ruínas Simbólicas",
+            "sangue" => "Campo Ritual",
+            _ => region.Biome
+        };
+
+        region.Biome = newBiome;
+        LandMemorySystem.RecordEvent(region.Name, $"Mudança de Bioma: {oldBiome} → {newBiome}", $"Causado por {trigger}");
+    }
+}

--- a/src/UltraWorldAI/World/LandMemorySystem.cs
+++ b/src/UltraWorldAI/World/LandMemorySystem.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class LandMemory
+{
+    public string RegionName { get; set; } = string.Empty;
+    public string Event { get; set; } = string.Empty;
+    public string Impact { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+}
+
+public static class LandMemorySystem
+{
+    public static List<LandMemory> Memories { get; } = new();
+
+    public static void RecordEvent(string region, string evt, string impact)
+    {
+        Memories.Add(new LandMemory
+        {
+            RegionName = region,
+            Event = evt,
+            Impact = impact,
+            Date = DateTime.Now
+        });
+    }
+
+    public static string DescribeAll()
+    {
+        if (Memories.Count == 0) return "A terra ainda não guarda memórias.";
+        return string.Join("\n\n", Memories.ConvertAll(m =>
+            $"\uD83D\uDDFF Em {m.RegionName}: {m.Event} ({m.Date.ToShortDateString()})\nImpacto: {m.Impact}"));
+    }
+}

--- a/src/UltraWorldAI/World/OrganicBorderSystem.cs
+++ b/src/UltraWorldAI/World/OrganicBorderSystem.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class BorderSegment
+{
+    public string RegionA { get; set; } = string.Empty;
+    public string RegionB { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public float Fluidity { get; set; }
+}
+
+public static class OrganicBorderSystem
+{
+    public static List<BorderSegment> Borders { get; } = new();
+
+    public static void GenerateBorders(List<WorldRegion> regions)
+    {
+        var rand = new Random();
+        for (int i = 0; i < regions.Count - 1; i++)
+        {
+            var border = new BorderSegment
+            {
+                RegionA = regions[i].Name,
+                RegionB = regions[i + 1].Name,
+                Type = rand.NextDouble() > 0.5 ? "Zona de Transição" : "Rio",
+                Fluidity = (float)Math.Round(rand.NextDouble(), 2)
+            };
+            Borders.Add(border);
+        }
+    }
+
+    public static string DescribeAll()
+    {
+        if (Borders.Count == 0) return "Nenhuma fronteira gerada.";
+        return string.Join("\n\n", Borders.ConvertAll(b =>
+            $"\uD83D\uDDFA {b.RegionA} ↔ {b.RegionB}\nTipo: {b.Type} | Fluidez: {b.Fluidity * 100}%"));
+    }
+}

--- a/src/UltraWorldAI/World/TerritoryClaimSystem.cs
+++ b/src/UltraWorldAI/World/TerritoryClaimSystem.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class TerritoryClaim
+{
+    public string RegionName { get; set; } = string.Empty;
+    public string ClaimedBy { get; set; } = string.Empty;
+    public DateTime ClaimDate { get; set; }
+    public string ClaimType { get; set; } = string.Empty;
+}
+
+public static class TerritoryClaimSystem
+{
+    public static List<TerritoryClaim> Claims { get; } = new();
+
+    public static void ClaimRegion(string region, string claimant, string type)
+    {
+        Claims.Add(new TerritoryClaim
+        {
+            RegionName = region,
+            ClaimedBy = claimant,
+            ClaimDate = DateTime.Now,
+            ClaimType = type
+        });
+    }
+
+    public static string DescribeAll()
+    {
+        if (Claims.Count == 0) return "Nenhuma região foi reivindicada.";
+        return string.Join("\n\n", Claims.ConvertAll(c =>
+            $"\uD83D\uDDFA {c.RegionName} foi reivindicada por {c.ClaimedBy} em {c.ClaimDate.ToShortDateString()}\nMotivo: {c.ClaimType}"));
+    }
+}

--- a/src/UltraWorldAI/World/WorldCaveSystem.cs
+++ b/src/UltraWorldAI/World/WorldCaveSystem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class CaveSystem
+{
+    public string Name { get; set; } = string.Empty;
+    public string LocatedInRegion { get; set; } = string.Empty;
+    public int DepthLevel { get; set; }
+    public bool IsConnectedToSurface { get; set; }
+    public List<string> Creatures { get; set; } = new();
+    public string Feature { get; set; } = string.Empty;
+}
+
+public static class WorldCaveSystem
+{
+    public static List<CaveSystem> Caves { get; } = new();
+
+    public static void GenerateCaves(List<WorldRegion> regions, int maxCaves)
+    {
+        var rand = new Random();
+        string[] features = { "Lago Subterrâneo", "Cristais Vivos", "Rede de Túneis", "Ruínas Antigas" };
+        string[] creatures = { "Vermes de Sangue", "Sapos Cegos", "Seres de Névoa", "Répteis Trogloditas" };
+
+        for (int i = 0; i < maxCaves; i++)
+        {
+            var region = regions[rand.Next(regions.Count)];
+            var cave = new CaveSystem
+            {
+                Name = "Caverna de " + region.Name,
+                LocatedInRegion = region.Name,
+                DepthLevel = rand.Next(1, 10),
+                IsConnectedToSurface = rand.NextDouble() > 0.4,
+                Creatures = new List<string> { creatures[rand.Next(creatures.Length)] },
+                Feature = features[rand.Next(features.Length)]
+            };
+            Caves.Add(cave);
+        }
+    }
+
+    public static string DescribeAll()
+    {
+        if (Caves.Count == 0) return "Nenhuma caverna foi criada.";
+        return string.Join("\n\n", Caves.ConvertAll(c =>
+            $"\uD83D\uDD73️ {c.Name} em {c.LocatedInRegion}\nProfundidade: {c.DepthLevel} | Acesso: {(c.IsConnectedToSurface ? "Sim" : "Não")}\nCriaturas: {string.Join(", ", c.Creatures)}\nElemento: {c.Feature}"));
+    }
+}

--- a/src/UltraWorldAI/World/WorldSeedGenerator.cs
+++ b/src/UltraWorldAI/World/WorldSeedGenerator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class WorldRegion
+{
+    public string Name { get; set; } = string.Empty;
+    public string Symbol { get; set; } = string.Empty;
+    public string Climate { get; set; } = string.Empty;
+    public string Biome { get; set; } = string.Empty;
+    public string ElementalAffinity { get; set; } = string.Empty;
+    public int Richness { get; set; }
+    public int MagicLevel { get; set; }
+    public int TechInfluence { get; set; }
+}
+
+public static class WorldSeedGenerator
+{
+    public static List<WorldRegion> Regions { get; } = new();
+
+    public static void Generate(int count)
+    {
+        string[] names = { "Orvak", "Ylendra", "Tiron", "Maraqu", "Koraith", "Valuun", "Luz de Vyr", "Noctovar" };
+        string[] biomes = { "Deserto Vazio", "Floresta Sombria", "Montanha Cantante", "Planície Viva", "Manguezal do Esquecimento" };
+        string[] climates = { "Árido", "Úmido", "Frio", "Instável", "Simbólico" };
+        string[] affinities = { "Fogo", "Água", "Sombra", "Luz", "Memória", "Sangue", "Vento", "Silêncio" };
+
+        var rand = new Random();
+        for (int i = 0; i < count; i++)
+        {
+            var region = new WorldRegion
+            {
+                Name = names[rand.Next(names.Length)] + "-" + rand.Next(1000, 9999),
+                Symbol = affinities[rand.Next(affinities.Length)],
+                Climate = climates[rand.Next(climates.Length)],
+                Biome = biomes[rand.Next(biomes.Length)],
+                ElementalAffinity = affinities[rand.Next(affinities.Length)],
+                Richness = rand.Next(40, 100),
+                MagicLevel = rand.Next(0, 100),
+                TechInfluence = rand.Next(0, 100)
+            };
+
+            Regions.Add(region);
+        }
+    }
+
+    public static string ListAll()
+    {
+        if (Regions.Count == 0) return "Nenhuma região gerada.";
+        return string.Join("\n\n", Regions.ConvertAll(r =>
+            $"\uD83C\uDF0D {r.Name} ({r.Biome})\nClima: {r.Climate} | Símbolo: {r.Symbol} | Afinidade: {r.ElementalAffinity}\nRiqueza: {r.Richness} | Magia: {r.MagicLevel} | Influência Tecnológica: {r.TechInfluence}"));
+    }
+}


### PR DESCRIPTION
## Summary
- create world region generator for basic map setup
- implement territory claims and land memories
- support environmental biome changes
- add organic borders and underground cave systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6841fca917d0832399f3a61c463a123d