### PR TITLE
Add sapient races and genetic systems

### DIFF
--- a/src/UltraWorldAI/Civilization/GenomicDecisionEngine.cs
+++ b/src/UltraWorldAI/Civilization/GenomicDecisionEngine.cs
@@ -1,0 +1,20 @@
+using UltraWorldAI.Civilization;
+using UltraWorldAI.Biology;
+
+namespace UltraWorldAI.Civilization;
+
+public static class GenomicDecisionEngine
+{
+    public static string Decide(SapientBeing being)
+    {
+        var expressed = being.GeneticCode.GetPhenotype().ToLower();
+
+        if (expressed.Contains("fome")) return "Caçar ou buscar alimento";
+        if (expressed.Contains("empatia")) return "Socializar e formar vínculos";
+        if (expressed.Contains("visão noturna")) return "Explorar à noite";
+        if (expressed.Contains("camuflagem")) return "Evitar conflito, se esconder";
+        if (expressed.Contains("magnetismo mental")) return "Influenciar outras IAs";
+
+        return "Ação neutra";
+    }
+}

--- a/src/UltraWorldAI/Civilization/IA_RaceLinker.cs
+++ b/src/UltraWorldAI/Civilization/IA_RaceLinker.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.Biology;
+
+namespace UltraWorldAI.Civilization;
+
+public class SapientBeing
+{
+    public string Name { get; set; } = string.Empty;
+    public string Race { get; set; } = string.Empty;
+    public Genome GeneticCode { get; set; } = new();
+    public int Age { get; set; }
+    public string CurrentRegion { get; set; } = string.Empty;
+}
+
+public static class IA_RaceLinker
+{
+    public static List<SapientBeing> Beings { get; } = new();
+
+    public static void CreateBeing(string name, string raceName)
+    {
+        var race = RaceRepository.Races.Find(r => r.Name == raceName);
+        if (race == null) throw new Exception("Raça não encontrada!");
+
+        var genome = GenerateGenomeFromRace(race);
+
+        Beings.Add(new SapientBeing
+        {
+            Name = name,
+            Race = race.Name,
+            GeneticCode = genome,
+            Age = 0,
+            CurrentRegion = race.OriginBiome
+        });
+    }
+
+    private static Genome GenerateGenomeFromRace(SapientRace race)
+    {
+        var genome = new Genome();
+
+        foreach (var trait in race.DominantGenes)
+        {
+            genome.Genes.Add(new Gene
+            {
+                Trait = trait,
+                AlleleA = trait.Substring(0, 1).ToUpper(),
+                AlleleB = trait.Substring(0, 1).ToLower(),
+                ExpressionType = AlleleType.Dominant
+            });
+        }
+
+        foreach (var weakness in race.Weaknesses)
+        {
+            genome.Genes.Add(new Gene
+            {
+                Trait = weakness,
+                AlleleA = "x",
+                AlleleB = "x",
+                ExpressionType = AlleleType.Recessive
+            });
+        }
+
+        return genome;
+    }
+}

--- a/src/UltraWorldAI/Civilization/InterRaceBreeding.cs
+++ b/src/UltraWorldAI/Civilization/InterRaceBreeding.cs
@@ -1,0 +1,27 @@
+using System;
+using UltraWorldAI.Biology;
+
+namespace UltraWorldAI.Civilization;
+
+public static class InterRaceBreeding
+{
+    public static SapientBeing? Breed(SapientBeing a, SapientBeing b)
+    {
+        if (!RaceGeneticCompatibility.CanCross(a.Race, b.Race))
+        {
+            Console.WriteLine("⚠️ Raças incompatíveis. Reprodução falhou.");
+            return null;
+        }
+
+        var childGenome = RaceGeneticCompatibility.CreateHybridGenome(a.GeneticCode, b.GeneticCode);
+
+        return new SapientBeing
+        {
+            Name = $"{a.Name.Substring(0, 2)}{b.Name.Substring(0, 2)}-{DateTime.Now.Ticks % 1000}",
+            Race = $"{a.Race}-{b.Race}",
+            Age = 0,
+            CurrentRegion = a.CurrentRegion,
+            GeneticCode = childGenome
+        };
+    }
+}

--- a/src/UltraWorldAI/Civilization/RaceCultureSystem.cs
+++ b/src/UltraWorldAI/Civilization/RaceCultureSystem.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Civilization;
+
+public class CulturalProfile
+{
+    public string RaceName { get; set; } = string.Empty;
+    public List<string> PreferredProfessions { get; set; } = new();
+    public string SocialStructure { get; set; } = string.Empty;
+    public string ArtStyle { get; set; } = string.Empty;
+    public string CommunicationMode { get; set; } = string.Empty;
+    public string SocialNorms { get; set; } = string.Empty;
+}
+
+public static class RaceCultureSystem
+{
+    public static List<CulturalProfile> Profiles { get; private set; } = new();
+
+    public static void GenerateAll()
+    {
+        Profiles = new()
+        {
+            new CulturalProfile
+            {
+                RaceName = "Humanos",
+                PreferredProfessions = new() { "Construtor", "Comerciante", "Explorador" },
+                SocialStructure = "Monarquia ou Democracia Emergente",
+                ArtStyle = "Narrativa e Escultura",
+                CommunicationMode = "Oratória e Escrita",
+                SocialNorms = "Contrato Social, Moralidade Adaptativa"
+            },
+            new CulturalProfile
+            {
+                RaceName = "Elfos",
+                PreferredProfessions = new() { "Guardião Natural", "Místico", "Músico" },
+                SocialStructure = "Conselhos Eternos",
+                ArtStyle = "Música Etérea, Pintura Bioluminescente",
+                CommunicationMode = "Telepatia, Rituais",
+                SocialNorms = "Equilíbrio, Estética e Harmonia"
+            },
+            new CulturalProfile
+            {
+                RaceName = "Anões",
+                PreferredProfessions = new() { "Ferreiro", "Minerador", "Engenheiro" },
+                SocialStructure = "Clãs Patriarcais",
+                ArtStyle = "Metalurgia Artística e Runas",
+                CommunicationMode = "Tambores, Códigos e Tatuagens",
+                SocialNorms = "Honra, Precisão, Herança"
+            },
+            new CulturalProfile
+            {
+                RaceName = "Gigantes",
+                PreferredProfessions = new() { "Caçador Solar", "Oráculo de Rocha" },
+                SocialStructure = "Círculos Temporais",
+                ArtStyle = "Cânticos Tectônicos",
+                CommunicationMode = "Eco Profundo",
+                SocialNorms = "Força, Silêncio e Legado"
+            },
+            new CulturalProfile
+            {
+                RaceName = "Fae",
+                PreferredProfessions = new() { "Ilusionista", "Colhedor de Névoa", "Contador de Histórias" },
+                SocialStructure = "Coletivos Temporários",
+                ArtStyle = "Efêmero e Fluido",
+                CommunicationMode = "Dança, Aroma, Imagem",
+                SocialNorms = "Instinto, Caos Poético"
+            }
+        };
+    }
+
+    public static CulturalProfile? GetForRace(string race)
+    {
+        return Profiles.Find(p => p.RaceName == race);
+    }
+
+    public static string Describe(string race)
+    {
+        var c = GetForRace(race);
+        if (c == null) return "Cultura não definida.";
+        return $"🏛️ {c.RaceName}\nEstrutura: {c.SocialStructure}\nProfissões: {string.Join(", ", c.PreferredProfessions)}\n" +
+               $"Arte: {c.ArtStyle} | Comunicação: {c.CommunicationMode}\nNormas: {c.SocialNorms}";
+    }
+}

--- a/src/UltraWorldAI/Civilization/RaceEvolutionSystem.cs
+++ b/src/UltraWorldAI/Civilization/RaceEvolutionSystem.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Civilization;
+
+public static class RaceEvolutionSystem
+{
+    public static Dictionary<string, Func<int, string>> AgeStageMap { get; } = new()
+    {
+        { "Humanos", age => age < 12 ? "Criança" : age < 20 ? "Jovem" : age < 60 ? "Adulto" : "Idoso" },
+        { "Elfos", age => age < 50 ? "Criança" : age < 150 ? "Jovem" : age < 900 ? "Adulto" : "Ancião" },
+        { "Anões", age => age < 20 ? "Criança" : age < 60 ? "Adulto" : "Ancião" },
+        { "Gigantes", age => age < 30 ? "Crescimento" : age < 80 ? "Força Máxima" : "Desgaste" },
+        { "Tieflings", age => age < 15 ? "Infância Roubada" : age < 40 ? "Fluxo Instável" : "Colapso ou Transcendência" },
+        { "Atlantes", age => age < 10 ? "Larva Mental" : age < 40 ? "Forma Estável" : "Silêncio Abissal" },
+        { "Insectoides", age => age < 1 ? "Ninfa" : age < 3 ? "Obreiro" : "Resíduo Genético" }
+    };
+
+    public static string GetLifeStage(string race, int age)
+    {
+        return AgeStageMap.ContainsKey(race) ? AgeStageMap[race](age) : "Desconhecido";
+    }
+}

--- a/src/UltraWorldAI/Civilization/RaceGeneticCompatibility.cs
+++ b/src/UltraWorldAI/Civilization/RaceGeneticCompatibility.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.Biology;
+
+namespace UltraWorldAI.Civilization;
+
+public static class RaceGeneticCompatibility
+{
+    private static readonly Dictionary<(string, string), bool> CompatibilityMap = new()
+    {
+        { ("Humanos", "Elfos"), true },
+        { ("Humanos", "Tieflings"), true },
+        { ("Elfos", "Fae"), true },
+        { ("Anões", "Gigantes"), false },
+        { ("Insectoides", "qualquer"), false },
+        { ("Atlantes", "Humanos"), true },
+        { ("Atlantes", "Elfos"), false },
+        { ("Tieflings", "Fae"), true }
+    };
+
+    public static bool CanCross(string raceA, string raceB)
+    {
+        return CompatibilityMap.ContainsKey((raceA, raceB)) ||
+               CompatibilityMap.ContainsKey((raceB, raceA)) ||
+               CompatibilityMap.ContainsKey((raceA, "qualquer")) ||
+               CompatibilityMap.ContainsKey(("qualquer", raceB));
+    }
+
+    public static Genome CreateHybridGenome(Genome g1, Genome g2)
+    {
+        if (g1.Genes.Count != g2.Genes.Count)
+            throw new Exception("Genomas incompatíveis em tamanho");
+
+        var hybrid = new Genome();
+        var rand = new Random();
+
+        for (int i = 0; i < g1.Genes.Count; i++)
+        {
+            string alleleA = rand.NextDouble() > 0.5 ? g1.Genes[i].AlleleA : g1.Genes[i].AlleleB;
+            string alleleB = rand.NextDouble() > 0.5 ? g2.Genes[i].AlleleA : g2.Genes[i].AlleleB;
+
+            hybrid.Genes.Add(new Gene
+            {
+                Trait = g1.Genes[i].Trait,
+                AlleleA = alleleA,
+                AlleleB = alleleB,
+                ExpressionType = g1.Genes[i].ExpressionType
+            });
+        }
+
+        GeneticMutation.Mutate(hybrid);
+        return hybrid;
+    }
+}

--- a/src/UltraWorldAI/Civilization/SapientRace.cs
+++ b/src/UltraWorldAI/Civilization/SapientRace.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Civilization;
+
+public class SapientRace
+{
+    public string Name { get; set; } = string.Empty;
+    public string OriginBiome { get; set; } = string.Empty;
+    public List<string> DominantGenes { get; set; } = new();
+    public List<string> Weaknesses { get; set; } = new();
+    public string CognitiveBias { get; set; } = string.Empty;
+    public string SociopoliticalTendency { get; set; } = string.Empty;
+    public string NaturalAffinity { get; set; } = string.Empty;
+}
+
+public static class RaceRepository
+{
+    public static List<SapientRace> Races { get; private set; } = new();
+
+    public static void CreateDefaults()
+    {
+        Races = new List<SapientRace>
+        {
+            new()
+            {
+                Name = "Humanos",
+                OriginBiome = "Planície Viva",
+                DominantGenes = new() { "Adaptação", "Memória Emocional", "Linguagem Expandida" },
+                Weaknesses = new() { "Vulnerabilidade Psicológica" },
+                CognitiveBias = "Expansão",
+                SociopoliticalTendency = "Reinos e Nações",
+                NaturalAffinity = "Diversidade Ambiental"
+            },
+            new()
+            {
+                Name = "Elfos",
+                OriginBiome = "Floresta Sombria",
+                DominantGenes = new() { "Visão Noturna", "Empatia", "Longevidade" },
+                Weaknesses = new() { "Estagnação Cultural" },
+                CognitiveBias = "Estética",
+                SociopoliticalTendency = "Conselhos Eternos",
+                NaturalAffinity = "Crescimento Vegetal"
+            },
+            new()
+            {
+                Name = "Anões",
+                OriginBiome = "Montanha Cantante",
+                DominantGenes = new() { "Resistência Óssea", "Trabalho Artesanal", "Foco Genético" },
+                Weaknesses = new() { "Baixa Adaptação Climática" },
+                CognitiveBias = "Precisão",
+                SociopoliticalTendency = "Clãs",
+                NaturalAffinity = "Pedra e Metal"
+            },
+            new()
+            {
+                Name = "Gigantes",
+                OriginBiome = "Planaltos Isolados",
+                DominantGenes = new() { "Força Bruta", "Lentidão Mental", "Memória Profunda" },
+                Weaknesses = new() { "Densidade de População", "Comida em Excesso" },
+                CognitiveBias = "Sobrevivência Territorial",
+                SociopoliticalTendency = "Alianças Temporais",
+                NaturalAffinity = "Céu e Montanhas"
+            },
+            new()
+            {
+                Name = "Reptilianos",
+                OriginBiome = "Deserto Vazio",
+                DominantGenes = new() { "Pele Escamosa", "Regulação de Calor", "Agressividade Condicionada" },
+                Weaknesses = new() { "Baixo Laço Social" },
+                CognitiveBias = "Supremacia Territorial",
+                SociopoliticalTendency = "Impérios Brutalistas",
+                NaturalAffinity = "Calor, Pedra e Subterrâneo"
+            },
+            new()
+            {
+                Name = "Fae",
+                OriginBiome = "Bosque Nebuloso",
+                DominantGenes = new() { "Magnetismo Mental", "Camuflagem Instintiva", "Pele Translúcida" },
+                Weaknesses = new() { "Fragilidade Física", "Impulsividade Sensorial" },
+                CognitiveBias = "Liberdade Instintiva",
+                SociopoliticalTendency = "Sementes de Coletivos Temporários",
+                NaturalAffinity = "Névoa, Flores e Luar"
+            },
+            new()
+            {
+                Name = "Tieflings",
+                OriginBiome = "Terras Queimadas",
+                DominantGenes = new() { "Resistência ao Calor", "Irradiação Etérica", "Olhos Infernais" },
+                Weaknesses = new() { "Preconceito Ancestral", "Risco de Transcendência Instável" },
+                CognitiveBias = "Sobrevivência Emocional",
+                SociopoliticalTendency = "Códigos Internos Orais",
+                NaturalAffinity = "Fendas, Cinzas, Rejeição"
+            },
+            new()
+            {
+                Name = "Atlantes",
+                OriginBiome = "Abismo Oceânico",
+                DominantGenes = new() { "Brânquias Cerebrais", "Telepatia Aquática", "Visão de Profundidade" },
+                Weaknesses = new() { "Secura Letal", "Tecnologia Instável" },
+                CognitiveBias = "Mistério",
+                SociopoliticalTendency = "Domínios Silenciosos",
+                NaturalAffinity = "Água Densa e Pressão"
+            },
+            new()
+            {
+                Name = "Insectoides",
+                OriginBiome = "Colméias de Cristal",
+                DominantGenes = new() { "Mente Coletiva", "Exoesqueleto Modular", "Ovo Simbiótico" },
+                Weaknesses = new() { "Padrões Fixos de Comportamento" },
+                CognitiveBias = "Eficiência",
+                SociopoliticalTendency = "Arquitetura de Casta",
+                NaturalAffinity = "Subsolo, Mel, Comunicação Química"
+            }
+        };
+    }
+
+    public static string ListAll()
+    {
+        return string.Join("\n\n", Races.ConvertAll(r =>
+            $"\uD83D\uDC64 {r.Name}\nBiome: {r.OriginBiome} | Tendência: {r.SociopoliticalTendency}\n" +
+            $"Genes: {string.Join(", ", r.DominantGenes)}\nFraquezas: {string.Join(", ", r.Weaknesses)}\n" +
+            $"Afinidade: {r.NaturalAffinity} | Tendência Cognitiva: {r.CognitiveBias}"));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SapientRace` and `RaceRepository` with default races
- add cross-race genetic compatibility and hybrid genome creation
- create beings linked to a race with genomes
- implement decision engine, evolution and breeding utilities
- describe cultural profiles for several races

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420428994483239104ed89f406d449