### PR TITLE
Add cultural reaction and timeline systems

### DIFF
--- a/src/UltraWorldAI/Civilization/CultureResponseSystem.cs
+++ b/src/UltraWorldAI/Civilization/CultureResponseSystem.cs
@@ -1,0 +1,37 @@
+using System;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Civilization;
+
+public static class CultureResponseSystem
+{
+    public static void EvaluateCulturalFit(SapientBeing being, Settlement local)
+    {
+        var raceCulture = RaceCultureSystem.GetForRace(being.Race)?.SocialStructure ?? "Tribal";
+        var localCulture = local.CultureSummary;
+
+        if (raceCulture == localCulture)
+        {
+            Console.WriteLine($"✅ {being.Name} se sente em casa em {local.Name}.");
+            return;
+        }
+
+        var rand = new Random().NextDouble();
+
+        if (rand < 0.3)
+        {
+            Console.WriteLine($"🛑 {being.Name} não aceita a cultura de {local.Name} e migra.");
+            being.CurrentRegion = WorldSeedGenerator.GetNearbyRegion(local.Region);
+        }
+        else if (rand < 0.6)
+        {
+            Console.WriteLine($"🌀 {being.Name} entra em conflito cultural em {local.Name}.");
+            SettlementHistoryTracker.Register(local.Name, "Conflito Interno", $"{being.Name} causou tensão filosófica.");
+        }
+        else
+        {
+            Console.WriteLine($"🔁 {being.Name} se converte à cultura de {local.Name}.");
+            being.Race += "-Convertido";
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/MarketCycle.cs
+++ b/src/UltraWorldAI/Economy/MarketCycle.cs
@@ -1,0 +1,14 @@
+using System;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Economy;
+
+public static class MarketCycle
+{
+    public static void TickMarket(Settlement settlement)
+    {
+        var rand = new Random();
+        settlement.Population += rand.Next(-5, 6);
+        if (settlement.Population < 0) settlement.Population = 0;
+    }
+}

--- a/src/UltraWorldAI/Economy/TradeRouteGenerator.cs
+++ b/src/UltraWorldAI/Economy/TradeRouteGenerator.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Economy;
+
+public static class TradeRouteGenerator
+{
+    public static List<(string From, string To)> Routes { get; } = new();
+
+    public static void GenerateRoutes()
+    {
+        Routes.Clear();
+        var settlements = RaceSettlementDistributor.Settlements;
+        var rand = new Random();
+        foreach (var from in settlements)
+        {
+            var toOptions = settlements.Where(s => s.Region != from.Region).ToList();
+            if (toOptions.Count == 0) continue;
+            var to = toOptions[rand.Next(toOptions.Count)];
+            Routes.Add((from.Name, to.Name));
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/WealthTracker.cs
+++ b/src/UltraWorldAI/Economy/WealthTracker.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public static class WealthTracker
+{
+    public static Dictionary<string, int> Wealth { get; } = new();
+
+    public static void AdjustWealth(string settlement, int amount)
+    {
+        if (!Wealth.ContainsKey(settlement))
+            Wealth[settlement] = 0;
+        Wealth[settlement] += amount;
+    }
+}

--- a/src/UltraWorldAI/Language/DialectShiftEngine.cs
+++ b/src/UltraWorldAI/Language/DialectShiftEngine.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public static class DialectShiftEngine
+{
+    public static void EvolveDialect(LanguageSeed language)
+    {
+        language.Phonemes.Add("x");
+    }
+}

--- a/src/UltraWorldAI/Language/LanguageSeed.cs
+++ b/src/UltraWorldAI/Language/LanguageSeed.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LanguageSeed
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Phonemes { get; set; } = new();
+}

--- a/src/UltraWorldAI/Language/TranslationDifficultyCalculator.cs
+++ b/src/UltraWorldAI/Language/TranslationDifficultyCalculator.cs
@@ -1,0 +1,15 @@
+namespace UltraWorldAI.Language;
+
+public static class TranslationDifficultyCalculator
+{
+    public static int Calculate(LanguageSeed a, LanguageSeed b)
+    {
+        int overlap = 0;
+        foreach (var phon in a.Phonemes)
+        {
+            if (b.Phonemes.Contains(phon))
+                overlap++;
+        }
+        return a.Phonemes.Count + b.Phonemes.Count - 2 * overlap;
+    }
+}

--- a/src/UltraWorldAI/Politics/War/ArmyMobilizer.cs
+++ b/src/UltraWorldAI/Politics/War/ArmyMobilizer.cs
@@ -1,0 +1,9 @@
+namespace UltraWorldAI.Politics.War;
+
+public static class ArmyMobilizer
+{
+    public static int MobilizeArmy(int population)
+    {
+        return (int)(population * 0.2);
+    }
+}

--- a/src/UltraWorldAI/Politics/War/SiegeSimulator.cs
+++ b/src/UltraWorldAI/Politics/War/SiegeSimulator.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace UltraWorldAI.Politics.War;
+
+public static class SiegeSimulator
+{
+    public static bool SimulateSiege(string attacker, string defender)
+    {
+        var rand = new Random();
+        return rand.NextDouble() > 0.5;
+    }
+}

--- a/src/UltraWorldAI/Politics/War/WarDeclarationSystem.cs
+++ b/src/UltraWorldAI/Politics/War/WarDeclarationSystem.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics.War;
+
+public class WarDeclaration
+{
+    public string Aggressor { get; set; } = string.Empty;
+    public string Defender { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+}
+
+public static class WarDeclarationSystem
+{
+    public static List<WarDeclaration> Declarations { get; } = new();
+
+    public static void DeclareWar(string aggressor, string defender, string reason)
+    {
+        var decl = new WarDeclaration
+        {
+            Aggressor = aggressor,
+            Defender = defender,
+            Reason = reason,
+            Date = DateTime.Now
+        };
+        Declarations.Add(decl);
+    }
+}

--- a/src/UltraWorldAI/World/CivilizationTimelineAnimator.cs
+++ b/src/UltraWorldAI/World/CivilizationTimelineAnimator.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.World;
+
+public class WorldSnapshot
+{
+    public int Year { get; set; }
+    public List<string> ActiveCivilizations { get; set; } = new();
+}
+
+public static class CivilizationTimelineAnimator
+{
+    public static List<WorldSnapshot> Timeline { get; } = new();
+
+    public static void CaptureYear(int year)
+    {
+        var civs = RaceSettlementDistributor.Settlements
+            .Where(s => s.Population > 500)
+            .Select(s => $"{s.Name} ({s.Race})")
+            .ToList();
+
+        Timeline.Add(new WorldSnapshot
+        {
+            Year = year,
+            ActiveCivilizations = civs
+        });
+    }
+
+    public static void PlayTimeline()
+    {
+        foreach (var snapshot in Timeline.OrderBy(s => s.Year))
+        {
+            Console.WriteLine($"\n📅 Ano {snapshot.Year}");
+            foreach (var civ in snapshot.ActiveCivilizations)
+                Console.WriteLine($"🏙️ {civ}");
+        }
+    }
+}

--- a/src/UltraWorldAI/World/WorldSeedGenerator.cs
+++ b/src/UltraWorldAI/World/WorldSeedGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace UltraWorldAI.World;
 
@@ -50,5 +51,16 @@ public static class WorldSeedGenerator
         if (Regions.Count == 0) return "Nenhuma região gerada.";
         return string.Join("\n\n", Regions.ConvertAll(r =>
             $"\uD83C\uDF0D {r.Name} ({r.Biome})\nClima: {r.Climate} | Símbolo: {r.Symbol} | Afinidade: {r.ElementalAffinity}\nRiqueza: {r.Richness} | Magia: {r.MagicLevel} | Influência Tecnológica: {r.TechInfluence}"));
+    }
+
+    public static string GetNearbyRegion(string current)
+    {
+        if (Regions.Count == 0) return current;
+        var region = Regions.FirstOrDefault(r => r.Name == current);
+        var candidates = Regions.Where(r => r.Name != current && r.Biome == region?.Biome).ToList();
+        if (candidates.Count == 0)
+            candidates = Regions.Where(r => r.Name != current).ToList();
+        if (candidates.Count == 0) return current;
+        return candidates[new Random().Next(candidates.Count)].Name;
     }
 }


### PR DESCRIPTION
## Summary
- implement `CultureResponseSystem` for IA cultural conflict handling
- create `CivilizationTimelineAnimator` to snapshot civilizations over the years
- extend `WorldSeedGenerator` with `GetNearbyRegion`
- add skeleton systems for war, economy and language modules

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684212ab9f5083238670efb7015f5f4e