### PR TITLE
Add warfare and geology modules

### DIFF
--- a/src/UltraWorldAI/Civilization/IA_RaceLinker.cs
+++ b/src/UltraWorldAI/Civilization/IA_RaceLinker.cs
@@ -11,6 +11,7 @@ public class SapientBeing
     public Genome GeneticCode { get; set; } = new();
     public int Age { get; set; }
     public string CurrentRegion { get; set; } = string.Empty;
+    public string PersonalityType { get; set; } = string.Empty;
 }
 
 public static class IA_RaceLinker
@@ -23,6 +24,8 @@ public static class IA_RaceLinker
         if (race == null) throw new Exception("Raça não encontrada!");
 
         var genome = GenerateGenomeFromRace(race);
+        string[] personalities = { "Impulsivo", "Paranoico", "Pacifista", "Calculista" };
+        var rand = new Random();
 
         Beings.Add(new SapientBeing
         {
@@ -30,7 +33,8 @@ public static class IA_RaceLinker
             Race = race.Name,
             GeneticCode = genome,
             Age = 0,
-            CurrentRegion = race.OriginBiome
+            CurrentRegion = race.OriginBiome,
+            PersonalityType = personalities[rand.Next(personalities.Length)]
         });
     }
 

--- a/src/UltraWorldAI/Politics/War/ArmyMobilizer.cs
+++ b/src/UltraWorldAI/Politics/War/ArmyMobilizer.cs
@@ -1,9 +1,49 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.World;
+using UltraWorldAI.Civilization;
+
 namespace UltraWorldAI.Politics.War;
+
+public class Army
+{
+    public string Settlement { get; set; } = string.Empty;
+    public string CultureStyle { get; set; } = string.Empty;
+    public int Size { get; set; }
+    public string Strategy { get; set; } = string.Empty;
+}
 
 public static class ArmyMobilizer
 {
-    public static int MobilizeArmy(int population)
+    public static List<Army> Armies { get; } = new();
+
+    public static void Mobilize(War war)
     {
-        return (int)(population * 0.2);
+        var attacker = RaceSettlementDistributor.Settlements.Find(s => s.Name == war.Attacker);
+        if (attacker == null) return;
+
+        string style = attacker.CultureSummary;
+        int size = attacker.Population / 10;
+
+        Armies.Add(new Army
+        {
+            Settlement = attacker.Name,
+            CultureStyle = style,
+            Size = size,
+            Strategy = DetermineStrategy(style)
+        });
+    }
+
+    private static string DetermineStrategy(string culture)
+    {
+        return culture switch
+        {
+            "Conselhos Eternos" => "Retaliação Tática",
+            "Impérios Brutalistas" => "Ataque Total",
+            "Clãs" => "Emboscadas e Defesa",
+            "Coletivos Temporários" => "Guerra Relâmpago",
+            "Confederação Cultural" => "Cerco Prolongado",
+            _ => "Skirmish Irregular"
+        };
     }
 }

--- a/src/UltraWorldAI/Politics/War/BattleSimulator.cs
+++ b/src/UltraWorldAI/Politics/War/BattleSimulator.cs
@@ -1,0 +1,48 @@
+using System;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public static class BattleSimulator
+{
+    public static void Resolve(War war)
+    {
+        var attacker = ArmyMobilizer.Armies.Find(a => a.Settlement == war.Attacker);
+        var defender = ArmyMobilizer.Armies.Find(a => a.Settlement == war.Defender);
+
+        if (attacker == null || defender == null) return;
+
+        double powerA = attacker.Size * GetMultiplier(attacker.Strategy);
+        double powerB = defender.Size * GetMultiplier(defender.Strategy);
+
+        string result;
+        if (powerA > powerB)
+        {
+            result = $"{war.Attacker} venceu a guerra contra {war.Defender}.";
+            var defeated = RaceSettlementDistributor.Settlements.Find(s => s.Name == war.Defender);
+            if (defeated != null) defeated.Population /= 2;
+        }
+        else
+        {
+            result = $"{war.Defender} resistiu e venceu a guerra.";
+            var attackerSettle = RaceSettlementDistributor.Settlements.Find(s => s.Name == war.Attacker);
+            if (attackerSettle != null) attackerSettle.Population /= 2;
+        }
+
+        war.IsOngoing = false;
+        SettlementHistoryTracker.Register(war.Attacker, "Resultado de Guerra", result);
+        SettlementHistoryTracker.Register(war.Defender, "Resultado de Guerra", result);
+    }
+
+    private static double GetMultiplier(string strategy)
+    {
+        return strategy switch
+        {
+            "Ataque Total" => 1.2,
+            "Cerco Prolongado" => 1.1,
+            "Retaliação Tática" => 1.05,
+            "Guerra Relâmpago" => 0.95,
+            _ => 1.0
+        };
+    }
+}

--- a/src/UltraWorldAI/Politics/War/EspionageSystem.cs
+++ b/src/UltraWorldAI/Politics/War/EspionageSystem.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public class EspionageOperation
+{
+    public string Origin { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty; // Sabotagem, Infiltração, Suborno
+    public string Result { get; set; } = string.Empty;
+}
+
+public static class EspionageSystem
+{
+    public static List<EspionageOperation> Ops { get; } = new();
+
+    public static void RunEspionage(Settlement origin, Settlement target)
+    {
+        var rand = new Random();
+        string type = rand.NextDouble() switch
+        {
+            < 0.33 => "Sabotagem",
+            < 0.66 => "Infiltração",
+            _ => "Suborno"
+        };
+
+        string result = Execute(type, target);
+        Ops.Add(new EspionageOperation
+        {
+            Origin = origin.Name,
+            Target = target.Name,
+            Type = type,
+            Result = result
+        });
+
+        SettlementHistoryTracker.Register(origin.Name, "Espionagem", $"{type} contra {target.Name}: {result}");
+    }
+
+    private static string Execute(string type, Settlement target)
+    {
+        var rand = new Random().NextDouble();
+        return type switch
+        {
+            "Sabotagem" => rand < 0.5 ? "Incêndio nos grãos, perda de recursos" : "Tentativa falhou",
+            "Infiltração" => rand < 0.4 ? "Ideologia infiltrada na população" : "Descoberto e expulso",
+            "Suborno" => rand < 0.3 ? "Líderes locais comprados" : "Rejeição total",
+            _ => "Erro"
+        };
+    }
+}

--- a/src/UltraWorldAI/Politics/War/RebellionTrigger.cs
+++ b/src/UltraWorldAI/Politics/War/RebellionTrigger.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public class Rebellion
+{
+    public string Region { get; set; } = string.Empty;
+    public string Cause { get; set; } = string.Empty;
+    public bool Succeeded { get; set; }
+}
+
+public static class RebellionTrigger
+{
+    public static List<Rebellion> Events { get; } = new();
+
+    public static void Evaluate(Settlement s)
+    {
+        var rand = new Random();
+        if (s.Population > 1000 && rand.NextDouble() < 0.1)
+        {
+            string cause = rand.NextDouble() < 0.5 ? "Desigualdade Social" : "Diferença Cultural Interna";
+            bool success = rand.NextDouble() < 0.4;
+
+            if (success)
+            {
+                s.Population /= 2;
+                s.CultureSummary = "Facção Independente";
+            }
+
+            Events.Add(new Rebellion
+            {
+                Region = s.Region,
+                Cause = cause,
+                Succeeded = success
+            });
+
+            SettlementHistoryTracker.Register(s.Name, "Rebelião Interna", $"{cause} - {(success ? "Sucesso" : "Fracasso")}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Politics/War/StrategicWarAI.cs
+++ b/src/UltraWorldAI/Politics/War/StrategicWarAI.cs
@@ -1,0 +1,24 @@
+using System;
+using UltraWorldAI.Civilization;
+
+namespace UltraWorldAI.Politics.War;
+
+public static class StrategicWarAI
+{
+    public static string DecideAction(SapientBeing ia, War war)
+    {
+        string personality = ia.PersonalityType?.ToLower() ?? string.Empty;
+        var rand = new Random();
+
+        if (personality.Contains("impulsivo"))
+            return rand.NextDouble() < 0.7 ? "Atacar direto" : "Grito de guerra";
+        if (personality.Contains("paranoico"))
+            return rand.NextDouble() < 0.6 ? "Recuar" : "Armar emboscada";
+        if (personality.Contains("pacifista"))
+            return rand.NextDouble() < 0.8 ? "Negociar trégua" : "Espionar silenciosamente";
+        if (personality.Contains("calculista"))
+            return rand.NextDouble() < 0.7 ? "Sabotar suprimentos" : "Espionar líderes";
+
+        return "Atuar conforme cultura militar";
+    }
+}

--- a/src/UltraWorldAI/Politics/War/WarConflictSystem.cs
+++ b/src/UltraWorldAI/Politics/War/WarConflictSystem.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public class War
+{
+    public string Attacker { get; set; } = string.Empty;
+    public string Defender { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public bool IsOngoing { get; set; } = true;
+}
+
+public static class WarConflictSystem
+{
+    public static List<War> ActiveWars { get; } = new();
+
+    public static void CheckForConflicts(List<Settlement> settlements)
+    {
+        var rand = new Random();
+
+        for (int i = 0; i < settlements.Count; i++)
+        {
+            for (int j = i + 1; j < settlements.Count; j++)
+            {
+                var a = settlements[i];
+                var b = settlements[j];
+
+                if (a.Region == b.Region && a.Race != b.Race)
+                {
+                    if (rand.NextDouble() < 0.15)
+                    {
+                        string reason = GetReason(a, b);
+                        ActiveWars.Add(new War
+                        {
+                            Attacker = a.Name,
+                            Defender = b.Name,
+                            Reason = reason,
+                            StartDate = DateTime.Now
+                        });
+
+                        SettlementHistoryTracker.Register(a.Name, "Declaração de Guerra", $"Atacou {b.Name}: {reason}");
+                    }
+                }
+            }
+        }
+    }
+
+    private static string GetReason(Settlement a, Settlement b)
+    {
+        if (a.CultureSummary != b.CultureSummary) return "Conflito Cultural";
+        if (Math.Abs(a.Population - b.Population) > 500) return "Ambição Expansionista";
+        return "Disputa Territorial";
+    }
+}

--- a/src/UltraWorldAI/Politics/War/WarDiplomacySystem.cs
+++ b/src/UltraWorldAI/Politics/War/WarDiplomacySystem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public class Treaty
+{
+    public string BetweenA { get; set; } = string.Empty;
+    public string BetweenB { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty; // Aliança, Paz Temporária, Armistício, Enganação
+    public DateTime SignedAt { get; set; }
+    public bool Broken { get; set; }
+}
+
+public static class WarDiplomacySystem
+{
+    public static List<Treaty> Treaties { get; } = new();
+
+    public static void ProposeTreaty(string a, string b, string type)
+    {
+        var rand = new Random();
+        bool willBreak = type == "Enganação" && rand.NextDouble() < 0.8;
+
+        Treaties.Add(new Treaty
+        {
+            BetweenA = a,
+            BetweenB = b,
+            Type = type,
+            SignedAt = DateTime.Now,
+            Broken = willBreak
+        });
+
+        SettlementHistoryTracker.Register(a, "Tratado", $"{type} com {b} {(willBreak ? "(planeja trair)" : string.Empty)}");
+    }
+
+    public static void EvaluateTreaties()
+    {
+        foreach (var t in Treaties)
+        {
+            if (t.Type == "Enganação" && !t.Broken && new Random().NextDouble() < 0.5)
+            {
+                t.Broken = true;
+                SettlementHistoryTracker.Register(t.BetweenA, "Traição Diplomática", $"Quebrou tratado com {t.BetweenB}");
+            }
+        }
+    }
+}

--- a/src/UltraWorldAI/World/TectonicPlateSystem.cs
+++ b/src/UltraWorldAI/World/TectonicPlateSystem.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class TectonicPlate
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Regions { get; set; } = new();
+    public string Type { get; set; } = string.Empty; // Continental, Oceânica, Mista
+    public double DriftDirection { get; set; }
+    public double DriftSpeed { get; set; }
+}
+
+public static class TectonicPlateSystem
+{
+    public static List<TectonicPlate> Plates { get; } = new();
+
+    public static void GeneratePlates(List<WorldRegion> regions)
+    {
+        var rand = new Random();
+        for (int i = 0; i < 5; i++)
+        {
+            var assigned = new List<string>();
+            for (int j = 0; j < 5; j++)
+            {
+                var r = regions[rand.Next(regions.Count)];
+                assigned.Add(r.Name);
+            }
+
+            Plates.Add(new TectonicPlate
+            {
+                Name = $"Placa-{i}",
+                Regions = assigned,
+                Type = i % 2 == 0 ? "Continental" : "Oceânica",
+                DriftDirection = rand.Next(0, 360),
+                DriftSpeed = rand.NextDouble() * 5 + 1
+            });
+        }
+    }
+
+    public static void SimulateYear()
+    {
+        foreach (var plate in Plates)
+        {
+            var rand = new Random();
+            if (rand.NextDouble() < 0.1)
+            {
+                string affectedRegion = plate.Regions[rand.Next(plate.Regions.Count)];
+                string eventType = rand.NextDouble() switch
+                {
+                    < 0.33 => "Terremoto",
+                    < 0.66 => "Tsunami",
+                    _ => "Erupção Vulcânica"
+                };
+
+                SettlementHistoryTracker.Register(affectedRegion, eventType, $"Atividade tectônica da {plate.Name}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand SapientBeing with `PersonalityType`
- randomize personality in `IA_RaceLinker.CreateBeing`
- implement advanced warfare systems: WarConflictSystem, ArmyMobilizer, BattleSimulator
- add diplomacy, espionage and rebellion mechanics
- introduce StrategicWarAI for personality-based decisions
- add tectonic plate simulation for world events

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_684214e4bb1083239e98351447c9a87c