### PR TITLE
Add warfare AI and dynamic terrain modules

### DIFF
--- a/src/UltraWorldAI/Politics/War/BeliefDrivenWarfare.cs
+++ b/src/UltraWorldAI/Politics/War/BeliefDrivenWarfare.cs
@@ -1,0 +1,38 @@
+using System;
+using UltraWorldAI.Religion;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public static class BeliefDrivenWarfare
+{
+    public static void EvaluateBeliefConflict(Settlement a, Settlement b)
+    {
+        var beliefA = CultureBeliefSystem.GetBelief(a.Race);
+        var beliefB = CultureBeliefSystem.GetBelief(b.Race);
+        if (beliefA == beliefB) return;
+
+        var cause = (beliefA, beliefB) switch
+        {
+            ("Purificação", _) => "Guerra Santa",
+            ("Expansão", _) => "Dominação Filosófica",
+            ("Equilíbrio", "Caos") => "Correção Cósmica",
+            ("Caos", "Ordem") => "Conflito Existencial",
+            (_, "Paz") => "Ataque contra pacifistas",
+            _ => "Divergência Dogmática"
+        };
+
+        if (new Random().NextDouble() < 0.2)
+        {
+            WarConflictSystem.ActiveWars.Add(new War
+            {
+                Attacker = a.Name,
+                Defender = b.Name,
+                Reason = cause,
+                StartDate = DateTime.Now
+            });
+
+            SettlementHistoryTracker.Register(a.Name, "Guerra por Crença", $"Atacou {b.Name} por: {cause}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Politics/War/TacticalTerrainAI.cs
+++ b/src/UltraWorldAI/Politics/War/TacticalTerrainAI.cs
@@ -1,0 +1,27 @@
+using System;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public static class TacticalTerrainAI
+{
+    public static string EvaluateStrategy(Army army, string terrainType, int enemySize)
+    {
+        string strategy = terrainType switch
+        {
+            "Floresta" => enemySize > army.Size ? "Emboscar e recuar" : "Atacar com cobertura",
+            "Montanha" => "Defender posição elevada",
+            "Planície" => army.Size > enemySize ? "Carga Frontal" : "Cercar pelas laterais",
+            "Deserto" => "Ataque rápido e disperso",
+            _ => "Aguardar oportunidade"
+        };
+
+        Console.WriteLine($"\U0001F9E0 Estratégia baseada no terreno ({terrainType}) e força inimiga: {strategy}");
+        return strategy;
+    }
+
+    public static string EvaluateSiege(Army army, Settlement target)
+    {
+        return target.Population > army.Size ? "Manter cerco e cortar suprimentos" : "Invasão imediata";
+    }
+}

--- a/src/UltraWorldAI/Politics/War/WarCommandAI.cs
+++ b/src/UltraWorldAI/Politics/War/WarCommandAI.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace UltraWorldAI.Politics.War;
+
+public enum Formation
+{
+    Linha,
+    Coluna,
+    Cercar,
+    Emboscada,
+    DefesaCircular
+}
+
+public static class WarCommandAI
+{
+    public static string Command(Army army, string terrainType)
+    {
+        var formation = ChooseFormation(army.CultureStyle, terrainType);
+        var action = ChooseAction();
+        Console.WriteLine($"\U0001F9E0 Exército de {army.Settlement} forma {formation} e decide: {action}");
+        return action;
+    }
+
+    private static Formation ChooseFormation(string culture, string terrain)
+    {
+        return terrain switch
+        {
+            "Floresta" => Formation.Emboscada,
+            "Montanha" => Formation.DefesaCircular,
+            "Planície" when culture.Contains("Brutal") => Formation.Coluna,
+            "Deserto" => Formation.Linha,
+            _ => Formation.Cercar
+        };
+    }
+
+    private static string ChooseAction()
+    {
+        var r = new Random().NextDouble();
+        if (r < 0.3) return "Avançar com força total";
+        if (r < 0.6) return "Posicionar e observar";
+        return "Fingir retirada e emboscar";
+    }
+}

--- a/src/UltraWorldAI/Politics/War/WarLogisticsAI.cs
+++ b/src/UltraWorldAI/Politics/War/WarLogisticsAI.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics.War;
+
+public class ArmyStatus
+{
+    public Army Army { get; set; } = new();
+    public int Supplies { get; set; }
+    public int Morale { get; set; }
+    public string Climate { get; set; } = string.Empty;
+}
+
+public static class WarLogisticsAI
+{
+    public static List<ArmyStatus> Statuses { get; } = new();
+
+    public static void UpdateStatus(Army army, string climate)
+    {
+        var rand = new Random();
+        var status = new ArmyStatus
+        {
+            Army = army,
+            Supplies = rand.Next(40, 100),
+            Morale = rand.Next(30, 100),
+            Climate = climate
+        };
+
+        if (climate == "Frio") status.Morale -= 10;
+        if (climate == "Chuva") status.Supplies -= 15;
+        if (climate == "Quente") status.Morale -= 5;
+
+        Statuses.Add(status);
+    }
+
+    public static string TacticalDecision(ArmyStatus status)
+    {
+        if (status.Supplies < 30)
+            return "Recuar para reabastecer";
+        if (status.Morale < 40)
+            return "Evitar combate e fortificar posição";
+        if (status.Climate == "Chuva" && status.Army.Strategy == "Guerra Relâmpago")
+            return "Atrasar avanço devido ao terreno encharcado";
+        return "Avançar com cautela e explorar vantagem";
+    }
+
+    public static void Execute()
+    {
+        foreach (var s in Statuses)
+        {
+            var decision = TacticalDecision(s);
+            Console.WriteLine($"\U0001F9E0 [Status de {s.Army.Settlement}] - Suprimentos: {s.Supplies}, Morale: {s.Morale}, Clima: {s.Climate}");
+            Console.WriteLine($"\U0001F50D Decisão Tática: {decision}\n");
+        }
+    }
+}

--- a/src/UltraWorldAI/Religion/CultureBeliefSystem.cs
+++ b/src/UltraWorldAI/Religion/CultureBeliefSystem.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public static class CultureBeliefSystem
+{
+    private static readonly Dictionary<string, string> Beliefs = new()
+    {
+        ["Humanos"] = "Expansão",
+        ["Elfos"] = "Equilíbrio",
+        ["Anões"] = "Purificação",
+        ["Gigantes"] = "Ordem",
+        ["Reptilianos"] = "Supremacia",
+        ["Fae"] = "Caos"
+    };
+
+    public static string GetBelief(string race)
+    {
+        return Beliefs.TryGetValue(race, out var belief) ? belief : "Paz";
+    }
+}

--- a/src/UltraWorldAI/World/DynamicTerrainModifier.cs
+++ b/src/UltraWorldAI/World/DynamicTerrainModifier.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+
+namespace UltraWorldAI.World;
+
+public static class DynamicTerrainModifier
+{
+    public static void ApplyEvent(string region, string eventType)
+    {
+        switch (eventType)
+        {
+            case "Terremoto":
+                SettlementHistoryTracker.Register(region, "Desastre", "Terreno rachado e instável.");
+                ForceMigration(region, 0.4);
+                break;
+            case "Tsunami":
+                SettlementHistoryTracker.Register(region, "Desastre", "Água invadiu estruturas e alterou margens.");
+                ForceMigration(region, 0.6);
+                break;
+            case "Erupção Vulcânica":
+                SettlementHistoryTracker.Register(region, "Mudança de Relevo", "Nova cadeia montanhosa formada.");
+                ForceMigration(region, 0.8);
+                break;
+        }
+    }
+
+    private static void ForceMigration(string region, double chance)
+    {
+        var settlements = RaceSettlementDistributor.Settlements.Where(s => s.Region == region).ToList();
+        var rand = new Random();
+        foreach (var s in settlements)
+        {
+            if (rand.NextDouble() < chance)
+            {
+                var old = s.Region;
+                s.Region = WorldSeedGenerator.GetNearbyRegion(old);
+                SettlementHistoryTracker.Register(s.Name, "Migração Forçada", $"Deixou {old}, foi para {s.Region}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DynamicTerrainModifier` to handle tectonic disasters and forced migrations
- introduce `WarCommandAI` for troop formations and actions
- handle supplies, morale, and climate via `WarLogisticsAI`
- enable ideology-based wars with `BeliefDrivenWarfare`
- add terrain-aware strategies in `TacticalTerrainAI`
- include `CultureBeliefSystem` for simple race beliefs

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684216d09c5083238a25174e3e5ad73a