### PR TITLE
Add deceptive war systems

### DIFF
--- a/src/UltraWorldAI/Politics/War/DoctrinalWarSystem.cs
+++ b/src/UltraWorldAI/Politics/War/DoctrinalWarSystem.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics.War;
+
+public class WarDoctrine
+{
+    public string Name { get; set; } = string.Empty;
+    public string Effect { get; set; } = string.Empty;
+}
+
+public class WarHeroAura
+{
+    public string HeroName { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty; // Moral, Ataque, Defesa, Inspiração
+    public int Radius { get; set; }
+    public int BoostAmount { get; set; }
+}
+
+public class MagicalEspionage
+{
+    public string TargetArmy { get; set; } = string.Empty;
+    public string SpellUsed { get; set; } = string.Empty; // Revelação, Corrupção, Fogo Silencioso
+    public bool Successful { get; set; }
+}
+
+public static class DoctrinalWarSystem
+{
+    public static List<WarDoctrine> Doctrines { get; } = new()
+    {
+        new WarDoctrine { Name = "Sacrifício", Effect = "Buff moral extremo com risco de perda" },
+        new WarDoctrine { Name = "Conversão", Effect = "Chance de corromper tropas inimigas" },
+        new WarDoctrine { Name = "Punição", Effect = "Dano adicional contra exércitos impuros" },
+        new WarDoctrine { Name = "Proteção", Effect = "Imunidade parcial a feitiços" }
+    };
+
+    public static WarDoctrine GetDoctrineForArmy(string beliefSystem)
+    {
+        return beliefSystem switch
+        {
+            "Purificação" => Doctrines.Find(d => d.Name == "Punição")!,
+            "Equilíbrio" => Doctrines.Find(d => d.Name == "Proteção")!,
+            "Expansão" => Doctrines.Find(d => d.Name == "Conversão")!,
+            _ => Doctrines.Find(d => d.Name == "Sacrifício")!
+        };
+    }
+
+    public static WarHeroAura GetAuraFromHero(WarHero hero)
+    {
+        return new WarHeroAura
+        {
+            HeroName = hero.Name,
+            Type = hero.FameLevel switch
+            {
+                >= 5 => "Inspiração",
+                >= 3 => "Moral",
+                _ => "Defesa"
+            },
+            Radius = 3 + hero.FameLevel,
+            BoostAmount = hero.FameLevel * 2
+        };
+    }
+
+    public static MagicalEspionage AttemptSpell(string targetArmy)
+    {
+        var rand = Random.Shared;
+        string spell = rand.NextDouble() switch
+        {
+            < 0.3 => "Revelação",
+            < 0.6 => "Corrupção",
+            _ => "Fogo Silencioso"
+        };
+
+        return new MagicalEspionage
+        {
+            TargetArmy = targetArmy,
+            SpellUsed = spell,
+            Successful = rand.NextDouble() < 0.5
+        };
+    }
+}

--- a/src/UltraWorldAI/Politics/War/MetaTrustAI.cs
+++ b/src/UltraWorldAI/Politics/War/MetaTrustAI.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.Civilization;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Politics.War;
+
+public class SecretPlan
+{
+    public string Actor { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public string PlanType { get; set; } = string.Empty; // Traição, Infiltração
+    public int TurnsToExecute { get; set; }
+}
+
+public static class MetaTrustAI
+{
+    public static List<SecretPlan> Plans { get; } = new();
+
+    public static void EvaluateMetaTrust(SapientBeing ia, Settlement target)
+    {
+        var rand = Random.Shared;
+        var rel = SettlementHistoryTracker.GetRelation(ia.CurrentRegion, target.Name);
+
+        bool isTrusted = rel.Contains("aliança", StringComparison.OrdinalIgnoreCase) && rand.NextDouble() < 0.7;
+        bool hasPastConflict = rel.Contains("traição", StringComparison.OrdinalIgnoreCase) ||
+                               rel.Contains("guerra", StringComparison.OrdinalIgnoreCase);
+
+        if (isTrusted && !hasPastConflict && rand.NextDouble() < 0.3)
+        {
+            string plan = rand.NextDouble() < 0.5 ? "Traição" : "Infiltração";
+            Plans.Add(new SecretPlan
+            {
+                Actor = ia.Name,
+                Target = target.Name,
+                PlanType = plan,
+                TurnsToExecute = rand.Next(3, 8)
+            });
+
+            Console.WriteLine($"\uD83E\uDD16 {ia.Name} finge amizade com {target.Name}, mas planeja: {plan}");
+        }
+    }
+
+    public static void AdvancePlans()
+    {
+        foreach (var plan in Plans.ToArray())
+        {
+            plan.TurnsToExecute--;
+            if (plan.TurnsToExecute <= 0)
+            {
+                Console.WriteLine($"\uD83D\uDD25 {plan.Actor} executa plano oculto contra {plan.Target}: {plan.PlanType}");
+                SettlementHistoryTracker.Register(plan.Target, "Traição Estratégica",
+                    $"{plan.Actor} executou plano de {plan.PlanType}");
+                Plans.Remove(plan);
+            }
+        }
+    }
+}

--- a/src/UltraWorldAI/Religion/CultureBeliefSystem.cs
+++ b/src/UltraWorldAI/Religion/CultureBeliefSystem.cs
@@ -18,4 +18,12 @@ public static class CultureBeliefSystem
     {
         return Beliefs.TryGetValue(race, out var belief) ? belief : "Paz";
     }
+
+    public static void ForceChangeBelief(string race, string newBelief)
+    {
+        if (string.IsNullOrWhiteSpace(race))
+            return;
+
+        Beliefs[race] = newBelief;
+    }
 }

--- a/src/UltraWorldAI/Religion/HiddenCultSystem.cs
+++ b/src/UltraWorldAI/Religion/HiddenCultSystem.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Religion;
+
+public class HiddenCult
+{
+    public string Name { get; set; } = string.Empty;
+    public string BeliefSystem { get; set; } = string.Empty;
+    public string TargetSettlement { get; set; } = string.Empty;
+    public int InfluenceLevel { get; set; }
+    public bool Discovered { get; set; }
+}
+
+public static class HiddenCultSystem
+{
+    public static List<HiddenCult> ActiveCults { get; } = new();
+
+    public static void SeedCult(string beliefSystem, string targetSettlement)
+    {
+        if (ActiveCults.Any(c => c.TargetSettlement == targetSettlement && !c.Discovered))
+            return;
+
+        var cult = new HiddenCult
+        {
+            Name = $"Culto de {beliefSystem}",
+            BeliefSystem = beliefSystem,
+            TargetSettlement = targetSettlement,
+            InfluenceLevel = 10
+        };
+
+        ActiveCults.Add(cult);
+        SettlementHistoryTracker.Register(targetSettlement, "Infiltração Espiritual",
+            $"Um culto secreto de {beliefSystem} começou a se formar.");
+    }
+
+    public static void AdvanceCultInfluence()
+    {
+        foreach (var cult in ActiveCults)
+        {
+            if (cult.Discovered)
+                continue;
+
+            cult.InfluenceLevel += Random.Shared.Next(1, 6);
+
+            if (cult.InfluenceLevel >= 70)
+            {
+                SettlementHistoryTracker.Register(cult.TargetSettlement, "Conversão Silenciosa",
+                    $"Grande parte da vila agora acredita em {cult.BeliefSystem}.");
+                CultureBeliefSystem.ForceChangeBelief(cult.TargetSettlement, cult.BeliefSystem);
+                cult.Discovered = true;
+            }
+            else if (Random.Shared.NextDouble() < 0.05)
+            {
+                cult.Discovered = true;
+                SettlementHistoryTracker.Register(cult.TargetSettlement, "Culto Descoberto",
+                    $"Autoridades locais descobriram o culto secreto de {cult.BeliefSystem}.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate strategic deception with `MetaTrustAI`
- add hidden cult influence via `HiddenCultSystem`
- expand war mechanics with `DoctrinalWarSystem`
- allow forcing belief changes in `CultureBeliefSystem`

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68421b0695308323b8b728672d0b9e8e