### PR TITLE
Improve memory system defaults

### DIFF
--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -15,7 +15,7 @@ namespace UltraWorldAI
         /// <summary>
         /// Short description of the event.
         /// </summary>
-        public string Summary { get; set; }
+        public string Summary { get; set; } = string.Empty;
 
         /// <summary>
         /// Time when the memory occurred.
@@ -45,7 +45,7 @@ namespace UltraWorldAI
         /// <summary>
         /// Source of the memory (e.g., self or external).
         /// </summary>
-        public string Source { get; set; }
+        public string Source { get; set; } = string.Empty;
 
         public Memory()
         {
@@ -262,6 +262,15 @@ namespace UltraWorldAI
         public Memory? GetMostIntenseMemory()
         {
             return Memories.OrderByDescending(m => m.Intensity).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Removes memories containing the specified keyword.
+        /// </summary>
+        public void RemoveMemoriesByKeyword(string keyword)
+        {
+            Memories.RemoveAll(m => m.Keywords.Any(k => k.Contains(keyword, StringComparison.OrdinalIgnoreCase)) ||
+                                   m.Summary.Contains(keyword, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/tests/UltraWorldAI.Tests/MemoryTests.cs
+++ b/tests/UltraWorldAI.Tests/MemoryTests.cs
@@ -49,4 +49,17 @@ public class MemoryTests
         Assert.NotNull(top);
         Assert.Equal("forte", top!.Summary);
     }
+
+    [Fact]
+    public void RemoveMemoriesByKeywordPurgesMatchingEntries()
+    {
+        var memSys = new MemorySystem();
+        memSys.AddMemory("alpha beta", 0.5f, 0f, new() { "alpha" });
+        memSys.AddMemory("gamma", 0.5f, 0f, new() { "gamma" });
+
+        memSys.RemoveMemoriesByKeyword("alpha");
+
+        Assert.DoesNotContain(memSys.Memories, m => m.Summary.Contains("alpha"));
+        Assert.Single(memSys.Memories);
+    }
 }


### PR DESCRIPTION
## Summary
- fix non-null warnings in `MemorySystem` by adding default values
- add `RemoveMemoriesByKeyword` helper
- cover new logic with a unit test

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68421d40b8908323acd4018ab4d7229f