### PR TITLE
Expand economic simulation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **DoctrineEngine** cria dogmas e textos sagrados.
 - **ProphecySystem** registra e cumpre profecias.
 - **CultSplit** gera cismas e novos cultos a partir de doutrinas.
+- **LivingEconomySystem** cria mercados dinâmicos e registra inflação.
+- **TradeCareerSystem** permite que IAs sigam carreiras econômicas e fundem guildas.
+- **BankingCollapseSystem** gerencia empréstimos e possíveis falências bancárias.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **xUnit tests** verificam memórias e resolução de contradições.
 

--- a/src/UltraWorldAI/Economy/BankingCollapseSystem.cs
+++ b/src/UltraWorldAI/Economy/BankingCollapseSystem.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class Loan
+{
+    public string Debtor { get; set; } = string.Empty;
+    public string Creditor { get; set; } = string.Empty;
+    public double Amount { get; set; }
+    public int TurnsLeft { get; set; }
+}
+
+public static class BankingCollapseSystem
+{
+    public static List<Loan> Loans { get; } = new();
+    public static Dictionary<string, double> BankWealth { get; } = new();
+
+    public static void GiveLoan(string bank, string debtor, double amount, int duration)
+    {
+        if (!BankWealth.ContainsKey(bank))
+            BankWealth[bank] = 1000;
+
+        if (BankWealth[bank] < amount)
+        {
+            Console.WriteLine($"💥 Banco {bank} quebrou ao tentar emprestar mais do que tem!");
+            return;
+        }
+
+        Loans.Add(new Loan
+        {
+            Debtor = debtor,
+            Creditor = bank,
+            Amount = amount,
+            TurnsLeft = duration
+        });
+
+        BankWealth[bank] -= amount;
+    }
+
+    public static void AdvanceLoans()
+    {
+        foreach (var loan in Loans.ToArray())
+        {
+            loan.TurnsLeft--;
+            if (loan.TurnsLeft <= 0)
+            {
+                bool defaulted = Random.Shared.NextDouble() < 0.3;
+                if (defaulted)
+                {
+                    // Banco perde capital permanentemente
+                }
+                else
+                {
+                    BankWealth[loan.Creditor] += loan.Amount * 1.2;
+                }
+            }
+        }
+
+        Loans.RemoveAll(l => l.TurnsLeft <= 0);
+    }
+}

--- a/src/UltraWorldAI/Economy/EconomicCrisisReactionAI.cs
+++ b/src/UltraWorldAI/Economy/EconomicCrisisReactionAI.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class EconomicProfile
+{
+    public string Name { get; set; } = string.Empty;
+    public double RiskTolerance { get; set; }
+    public bool IsFraudulent { get; set; }
+    public double Capital { get; set; }
+}
+
+public static class EconomicCrisisReactionAI
+{
+    public static List<EconomicProfile> Profiles { get; } = new();
+
+    public static void RegisterIA(string name, double capital)
+    {
+        Profiles.Add(new EconomicProfile
+        {
+            Name = name,
+            Capital = capital,
+            RiskTolerance = Random.Shared.NextDouble(),
+            IsFraudulent = false
+        });
+    }
+
+    public static void EvaluateCrisis(string settlement, double inflation)
+    {
+        foreach (var ia in Profiles)
+        {
+            if (inflation > 1.5 && ia.RiskTolerance > 0.7)
+            {
+                ia.Capital *= 1.2;
+                SettlementHistoryTracker.Register(settlement, "Especulação", $"{ia.Name} lucrou durante a crise.");
+                if (Random.Shared.NextDouble() < 0.3)
+                {
+                    ia.IsFraudulent = true;
+                    SettlementHistoryTracker.Register(settlement, "Fraude", $"{ia.Name} iniciou um esquema fraudulento.");
+                }
+            }
+            else if (inflation > 2.0)
+            {
+                ia.Capital *= 0.7;
+                SettlementHistoryTracker.Register(settlement, "Perda Econômica", $"{ia.Name} perdeu riqueza na crise.");
+            }
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/GeoEconomicConflictSystem.cs
+++ b/src/UltraWorldAI/Economy/GeoEconomicConflictSystem.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class TradeSanction
+{
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public int Duration { get; set; }
+    public string Reason { get; set; } = string.Empty;
+}
+
+public static class GeoEconomicConflictSystem
+{
+    public static List<TradeSanction> Sanctions { get; } = new();
+
+    public static void DeclareSanction(string from, string to, string reason)
+    {
+        Sanctions.Add(new TradeSanction
+        {
+            From = from,
+            To = to,
+            Duration = 5,
+            Reason = reason
+        });
+
+        SettlementHistoryTracker.Register(to, "Sanção Econômica", $"{from} sancionou por: {reason}");
+    }
+
+    public static void AdvanceSanctions()
+    {
+        foreach (var s in Sanctions)
+            s.Duration--;
+        Sanctions.RemoveAll(s => s.Duration <= 0);
+    }
+
+    public static void AttemptCorruption(string target, string actor)
+    {
+        var chance = Random.Shared.NextDouble();
+        if (chance < 0.4)
+            SettlementHistoryTracker.Register(target, "Corrupção", $"{actor} subornou líderes.");
+        else
+            SettlementHistoryTracker.Register(target, "Corrupção Falhou", $"{actor} tentou subornar sem sucesso.");
+    }
+}

--- a/src/UltraWorldAI/Economy/LivingEconomySystem.cs
+++ b/src/UltraWorldAI/Economy/LivingEconomySystem.cs
@@ -70,6 +70,8 @@ public static class LivingEconomySystem
                 market.InflationFactor += 0.1;
                 SettlementHistoryTracker.Register(market.Settlement, "Inflação", "Preços subiram por instabilidade interna.");
             }
+
+            EconomicCrisisReactionAI.EvaluateCrisis(market.Settlement, market.InflationFactor);
         }
     }
 

--- a/src/UltraWorldAI/Economy/TradeCareerSystem.cs
+++ b/src/UltraWorldAI/Economy/TradeCareerSystem.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class TradeRoute
+{
+    public string Origin { get; set; } = string.Empty;
+    public string Destination { get; set; } = string.Empty;
+    public string Good { get; set; } = string.Empty;
+    public double Volume { get; set; }
+}
+
+public class TradeGuild
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> ControlledSettlements { get; } = new();
+    public double Wealth { get; set; }
+}
+
+public class EconomicCareer
+{
+    public string Name { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty; // Mercador, Contrabandista, Banqueiro
+    public double Capital { get; set; }
+    public string? GuildAffiliation { get; set; }
+}
+
+public static class TradeCareerSystem
+{
+    public static List<TradeRoute> Routes { get; } = new();
+    public static List<TradeGuild> Guilds { get; } = new();
+    public static List<EconomicCareer> ActiveIAs { get; } = new();
+
+    public static void CreateCareer(string iaName, string role)
+    {
+        var capital = Random.Shared.Next(100, 1000);
+        ActiveIAs.Add(new EconomicCareer
+        {
+            Name = iaName,
+            Role = role,
+            Capital = capital
+        });
+    }
+
+    public static void RegisterRoute(string origin, string destination, string good)
+    {
+        var route = new TradeRoute
+        {
+            Origin = origin,
+            Destination = destination,
+            Good = good,
+            Volume = Random.Shared.Next(50, 200)
+        };
+        Routes.Add(route);
+    }
+
+    public static void CreateGuild(string name, string initialSettlement)
+    {
+        Guilds.Add(new TradeGuild
+        {
+            Name = name,
+            Wealth = 1000,
+            ControlledSettlements = { initialSettlement }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- document new economy subsystems in `README`
- integrate crisis reactions inside `LivingEconomySystem`
- add `TradeCareerSystem` for trade routes and guilds
- add `BankingCollapseSystem` to manage loans and collapses
- add `EconomicCrisisReactionAI` for speculation and fraud logic
- add `GeoEconomicConflictSystem` for sanctions and corruption

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422195dab88323a9c39b88bae63714