### PR TITLE
Integrate cultural reputation economy systems

### DIFF
--- a/src/UltraWorldAI/Economy/AdaptiveTradeAI.cs
+++ b/src/UltraWorldAI/Economy/AdaptiveTradeAI.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class TradeMemory
+{
+    public string IAName { get; set; } = string.Empty;
+    public List<string> SuccessfulGoods { get; } = new();
+    public List<string> FailedGoods { get; } = new();
+    public int ExperienceLevel { get; set; }
+}
+
+public static class AdaptiveTradeAI
+{
+    public static List<TradeMemory> Profiles { get; } = new();
+
+    public static void Register(string name)
+    {
+        Profiles.Add(new TradeMemory { IAName = name });
+    }
+
+    public static void RecordTrade(string name, string good, bool success)
+    {
+        var profile = Profiles.Find(p => p.IAName == name);
+        if (profile == null) return;
+
+        if (success)
+        {
+            if (!profile.SuccessfulGoods.Contains(good))
+                profile.SuccessfulGoods.Add(good);
+            profile.ExperienceLevel++;
+        }
+        else
+        {
+            if (!profile.FailedGoods.Contains(good))
+                profile.FailedGoods.Add(good);
+            profile.ExperienceLevel--;
+        }
+
+        Console.WriteLine($"\uD83E\uDD16 {name} aprendeu com o trade de {good}: {(success ? "sucesso" : "falha")}");
+    }
+
+    public static string RecommendNextGood(string name)
+    {
+        var profile = Profiles.Find(p => p.IAName == name);
+        if (profile == null || profile.SuccessfulGoods.Count == 0) return "Aleatório";
+
+        return profile.SuccessfulGoods[Random.Shared.Next(profile.SuccessfulGoods.Count)];
+    }
+}

--- a/src/UltraWorldAI/Economy/CulturalMarketSystem.cs
+++ b/src/UltraWorldAI/Economy/CulturalMarketSystem.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class CulturalPreference
+{
+    public string Culture { get; set; } = string.Empty;
+    public string Race { get; set; } = string.Empty;
+    public List<string> PreferredGoods { get; set; } = new();
+    public List<string> TabooGoods { get; set; } = new();
+    public string ExchangeModel { get; set; } = string.Empty;
+}
+
+public static class CulturalMarketSystem
+{
+    public static List<CulturalPreference> Preferences { get; } = new();
+
+    public static void RegisterCulture(string culture, string race, string exchange)
+    {
+        Preferences.Add(new CulturalPreference
+        {
+            Culture = culture,
+            Race = race,
+            ExchangeModel = exchange,
+            PreferredGoods = GenerateGoods(exchange, true),
+            TabooGoods = GenerateGoods(exchange, false)
+        });
+    }
+
+    private static List<string> GenerateGoods(string model, bool preferred)
+    {
+        if (model == "Oferta Ritual")
+            return preferred
+                ? new() { "Arte", "Runas", "Animais Raros" }
+                : new() { "Ferro", "Moeda" };
+        if (model == "Prestígio")
+            return preferred
+                ? new() { "História", "Títulos", "Serviços" }
+                : new() { "Alimentos Básicos" };
+        if (model == "Serviço")
+            return preferred
+                ? new() { "Trabalho", "Troca de Conhecimento" }
+                : new() { "Tesouros" };
+        return preferred
+            ? new() { "Moeda", "Comida", "Ferramentas" }
+            : new List<string>();
+    }
+
+    public static bool CanTrade(string culture, string good)
+    {
+        var pref = Preferences.Find(p => p.Culture == culture);
+        if (pref == null) return false;
+        return !pref.TabooGoods.Contains(good);
+    }
+}

--- a/src/UltraWorldAI/Economy/EconomicCrisisReactionAI.cs
+++ b/src/UltraWorldAI/Economy/EconomicCrisisReactionAI.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UltraWorldAI.World;
 
 namespace UltraWorldAI.Economy;
 

--- a/src/UltraWorldAI/Economy/EconomicReputationTracker.cs
+++ b/src/UltraWorldAI/Economy/EconomicReputationTracker.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class EconomicReputation
+{
+    public string Name { get; set; } = string.Empty;
+    public double CreditRating { get; set; } = 50;
+    public int FraudCount { get; set; }
+    public int LoanSuccess { get; set; }
+    public int LoanDefault { get; set; }
+}
+
+public static class EconomicReputationTracker
+{
+    public static List<EconomicReputation> Profiles { get; } = new();
+
+    public static void Register(string name)
+    {
+        Profiles.Add(new EconomicReputation { Name = name });
+    }
+
+    public static void RecordLoanResult(string name, bool success)
+    {
+        var profile = Profiles.Find(p => p.Name == name);
+        if (profile == null) return;
+
+        if (success)
+        {
+            profile.LoanSuccess++;
+            profile.CreditRating += 5;
+        }
+        else
+        {
+            profile.LoanDefault++;
+            profile.CreditRating -= 10;
+        }
+
+        profile.CreditRating = Math.Clamp(profile.CreditRating, 0, 100);
+    }
+
+    public static void RecordFraud(string name)
+    {
+        var profile = Profiles.Find(p => p.Name == name);
+        if (profile == null) return;
+
+        profile.FraudCount++;
+        profile.CreditRating -= 20;
+        profile.CreditRating = Math.Clamp(profile.CreditRating, 0, 100);
+    }
+
+    public static string GetTrustStatus(string name)
+    {
+        var profile = Profiles.Find(p => p.Name == name);
+        if (profile == null) return "Desconhecido";
+
+        if (profile.CreditRating > 80) return "Confiável";
+        if (profile.CreditRating > 50) return "Moderado";
+        if (profile.CreditRating > 20) return "Desconfiado";
+        return "Perigoso";
+    }
+}

--- a/src/UltraWorldAI/Economy/GeoEconomicConflictSystem.cs
+++ b/src/UltraWorldAI/Economy/GeoEconomicConflictSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UltraWorldAI.World;
 
 namespace UltraWorldAI.Economy;
 

--- a/src/UltraWorldAI/Economy/SpiritualEconomicIntegration.cs
+++ b/src/UltraWorldAI/Economy/SpiritualEconomicIntegration.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class DivineTax
+{
+    public string Deity { get; set; } = string.Empty;
+    public string Culture { get; set; } = string.Empty;
+    public double TaxRate { get; set; }
+    public string TempleSettlement { get; set; } = string.Empty;
+}
+
+public static class SpiritualEconomicIntegration
+{
+    public static List<DivineTax> DivineTaxes { get; } = new();
+
+    public static void RegisterDivineTax(string deity, string culture, double rate, string temple)
+    {
+        DivineTaxes.Add(new DivineTax
+        {
+            Deity = deity,
+            Culture = culture,
+            TaxRate = rate,
+            TempleSettlement = temple
+        });
+    }
+
+    public static void ProcessTithes(string culture, double localIncome)
+    {
+        foreach (var tax in DivineTaxes)
+        {
+            if (tax.Culture != culture) continue;
+            double tithe = localIncome * tax.TaxRate;
+            Console.WriteLine($"\uD83D\uDCB8 {culture} doou {tithe:F2} moedas a {tax.Deity} no templo de {tax.TempleSettlement}");
+        }
+    }
+
+    public static void TriggerHistoricEconomicEvent(string settlement, string eventType)
+    {
+        string message = eventType switch
+        {
+            "Era de Ouro" => $"{settlement} entrou em uma era de ouro, o comércio floresce.",
+            "Queda Cultural" => $"{settlement} sofre recessão por colapso filosófico.",
+            "Guerra Santa" => $"{settlement} muda produção para suportar cruzada espiritual.",
+            _ => $"{settlement} sofreu um evento econômico."
+        };
+
+        Console.WriteLine($"\uD83D\uDCDC Evento Histórico: {message}");
+    }
+}


### PR DESCRIPTION
## Summary
- create cultural market system for trade restrictions
- add economic reputation tracker for credit history
- implement spiritual economy hooks for tithes and historic events
- introduce adaptive trade AI that learns from successes
- reference `SettlementHistoryTracker` in existing economy modules

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_684223af029083239e2490719808ef2e