### PR TITLE
Add map economy-faith systems

### DIFF
--- a/src/UltraWorldAI/GeoEconomicDecisionAI.cs
+++ b/src/UltraWorldAI/GeoEconomicDecisionAI.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI;
+
+public static class GeoEconomicDecisionAI
+{
+    public static void EvaluateSettlement(string iaName, string currentLocation, string faith, double wealth)
+    {
+        var richer = MapFaithEconomyIntegration.Nodes
+            .Where(n => n.Wealth > wealth + 200)
+            .OrderByDescending(n => n.Wealth)
+            .FirstOrDefault();
+
+        if (richer != null)
+        {
+            SettlementHistoryTracker.Register(currentLocation, "Migração", $"{iaName} mudou-se para {richer.Settlement}");
+            Console.WriteLine($"\uD83C\uDFC3 {iaName} migrou de {currentLocation} para {richer.Settlement} buscando prosperidade.");
+        }
+
+        var dominantFaith = MapFaithEconomyIntegration.Nodes
+            .Where(n => n.Settlement == currentLocation)
+            .Select(n => n.DominantFaith)
+            .FirstOrDefault();
+
+        if (!string.IsNullOrEmpty(dominantFaith) && dominantFaith != faith)
+        {
+            SettlementHistoryTracker.Register(currentLocation, "Conversão", $"{iaName} adotou a fé {dominantFaith}");
+            Console.WriteLine($"\u26EA {iaName} converteu-se de {faith} para {dominantFaith} em {currentLocation}.");
+        }
+
+        var target = MapFaithEconomyIntegration.Nodes
+            .Where(n => n.Wealth > 1000 && n.DominantFaith != faith)
+            .OrderByDescending(n => n.Wealth)
+            .FirstOrDefault();
+
+        if (target != null)
+        {
+            SettlementHistoryTracker.Register(target.Settlement, "Conflito Econômico", $"{iaName} tenta dominar o mercado");
+            Console.WriteLine($"\u2694\uFE0F {iaName} lidera investida econômica contra {target.Settlement}, tentando tomar controle.");
+        }
+    }
+}

--- a/src/UltraWorldAI/World/DynamicInfrastructureSystem.cs
+++ b/src/UltraWorldAI/World/DynamicInfrastructureSystem.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public class Infrastructure
+{
+    public string Settlement { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Trigger { get; set; } = string.Empty;
+}
+
+public static class DynamicInfrastructureSystem
+{
+    public static List<Infrastructure> AllStructures { get; } = new();
+
+    public static void UpdateInfrastructure()
+    {
+        foreach (var node in MapFaithEconomyIntegration.Nodes)
+        {
+            if (node.Wealth > 1500 && !node.HasMarket)
+            {
+                AllStructures.Add(new Infrastructure
+                {
+                    Settlement = node.Settlement,
+                    Type = "Mercado Central",
+                    Trigger = "Riqueza"
+                });
+                node.HasMarket = true;
+                SettlementHistoryTracker.Register(node.Settlement, "Construção", "Mercado Central erguido.");
+                Console.WriteLine($"\uD83D\uDD3D️ {node.Settlement} construiu um Mercado Central por excesso de riqueza.");
+            }
+
+            if (!node.HasTemple && !string.IsNullOrEmpty(node.DominantFaith))
+            {
+                AllStructures.Add(new Infrastructure
+                {
+                    Settlement = node.Settlement,
+                    Type = $"Templo de {node.DominantFaith}",
+                    Trigger = "Fé"
+                });
+                node.HasTemple = true;
+                SettlementHistoryTracker.Register(node.Settlement, "Construção", $"Templo dedicado a {node.DominantFaith}");
+                Console.WriteLine($"\uD83D\uDD3D️ {node.Settlement} ergueu o Templo de {node.DominantFaith} por influência espiritual.");
+            }
+
+            if (node.Wealth < 200 && node.HasMarket)
+            {
+                AllStructures.Add(new Infrastructure
+                {
+                    Settlement = node.Settlement,
+                    Type = "Ruínas Comerciais",
+                    Trigger = "Declínio"
+                });
+                node.HasMarket = false;
+                SettlementHistoryTracker.Register(node.Settlement, "Declínio", "Mercado transformou-se em ruínas.");
+                Console.WriteLine($"\uD83D\uDC80 {node.Settlement} perdeu seu mercado. Agora restam ruínas econômicas.");
+            }
+        }
+    }
+}

--- a/src/UltraWorldAI/World/MapFaithEconomyIntegration.cs
+++ b/src/UltraWorldAI/World/MapFaithEconomyIntegration.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.World;
+
+public class EconomicNode
+{
+    public string Settlement { get; set; } = string.Empty;
+    public double Wealth { get; set; }
+    public bool HasMarket { get; set; }
+    public bool HasTemple { get; set; }
+    public string DominantFaith { get; set; } = string.Empty;
+}
+
+public class TradeLink
+{
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public string Good { get; set; } = string.Empty;
+    public double FlowAmount { get; set; }
+}
+
+public static class MapFaithEconomyIntegration
+{
+    public static List<EconomicNode> Nodes { get; } = new();
+    public static List<TradeLink> TradeRoutes { get; } = new();
+
+    public static void RegisterNode(string settlement, double wealth, bool market, bool temple, string faith)
+    {
+        if (Nodes.Any(n => n.Settlement == settlement)) return;
+
+        Nodes.Add(new EconomicNode
+        {
+            Settlement = settlement,
+            Wealth = wealth,
+            HasMarket = market,
+            HasTemple = temple,
+            DominantFaith = faith
+        });
+
+        SettlementHistoryTracker.Register(settlement, "Registro Econômico", "Assentamento mapeado para economia e fé.");
+        Console.WriteLine($"\uD83D\uDCCD {settlement} adicionado ao mapa: mercado={market}, templo={temple}, fé={faith}");
+    }
+
+    public static void CreateTradeRoute(string from, string to, string good, double volume)
+    {
+        TradeRoutes.Add(new TradeLink
+        {
+            From = from,
+            To = to,
+            Good = good,
+            FlowAmount = volume
+        });
+
+        SettlementHistoryTracker.Register(from, "Rota Comercial", $"Enviado {good} para {to} ({volume}).");
+        Console.WriteLine($"\uD83D\uDCE6 Rota criada: {good} de {from} → {to} ({volume} unidades)");
+    }
+
+    public static void UpdateNodeWealth(string settlement, double delta)
+    {
+        var node = Nodes.FirstOrDefault(n => n.Settlement == settlement);
+        if (node == null) return;
+
+        node.Wealth = Math.Max(0, node.Wealth + delta);
+        SettlementHistoryTracker.Register(settlement, "Mudança de Riqueza", $"Nova riqueza: {node.Wealth:F2}");
+        Console.WriteLine($"\uD83D\uDCB0 {settlement} agora tem riqueza: {node.Wealth:F2}");
+    }
+
+    public static string GetMapOverview()
+    {
+        return string.Join('\n', Nodes.Select(n =>
+            $"\uD83C\uDF0D {n.Settlement} | Riqueza: {n.Wealth:F1} | Fé: {n.DominantFaith} | Mercado: {n.HasMarket} | Templo: {n.HasTemple}"));
+    }
+
+    public static List<string> GetFaithZones(string deity)
+    {
+        return Nodes.Where(n => n.DominantFaith == deity).Select(n => n.Settlement).ToList();
+    }
+
+    public static double GetTradeVolume(string good)
+    {
+        return TradeRoutes.Where(r => r.Good == good).Sum(r => r.FlowAmount);
+    }
+
+    public static void InitializeFromSettlements()
+    {
+        foreach (var settlement in RaceSettlementDistributor.Settlements)
+        {
+            RegisterNode(
+                settlement.Name,
+                Random.Shared.Next(500, 1200),
+                market: false,
+                temple: false,
+                faith: "Desconhecida");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate economic map nodes and trade links with faith data
- track AI migration, conversion and conflict decisions across the map
- build infrastructure dynamically based on wealth and faith

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684225c09c9c8323934a8b6826492ec7