### PR TITLE
Add economic heritage systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **LivingEconomySystem** cria mercados dinâmicos e registra inflação.
 - **TradeCareerSystem** permite que IAs sigam carreiras econômicas e fundem guildas.
 - **BankingCollapseSystem** gerencia empréstimos e possíveis falências bancárias.
+- **EvolvingRaceEconomy** modela estilos de troca que evoluem por raça.
+- **HeirloomEconomySystem** registra legados e mutações de modelos econômicos.
+- **EconomicLineageVisualizer** exibe genealogias econômicas como árvores.
+- **EconomicModelInteractionSystem** documenta fusões e conflitos entre modelos.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **xUnit tests** verificam memórias e resolução de contradições.
 

--- a/src/UltraWorldAI/Economy/EconomicLineageVisualizer.cs
+++ b/src/UltraWorldAI/Economy/EconomicLineageVisualizer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public static class EconomicLineageVisualizer
+{
+    public static void PrintTree(string rootCulture, List<EconomicHeirloom> history)
+    {
+        Console.WriteLine($"\uD83C\uDF33 Linhagem Econ\u00f4mica de {rootCulture}:\n");
+        Traverse(rootCulture, history, 0);
+    }
+
+    private static void Traverse(string culture, List<EconomicHeirloom> history, int indent)
+    {
+        var children = history
+            .Where(h => h.OriginCulture == culture)
+            .OrderBy(h => h.Year)
+            .ToList();
+
+        foreach (var child in children)
+        {
+            string line = new(' ', indent * 2);
+            line += $"\u2192 {child.InheritorCulture} ({child.MutationType}) {child.OriginalModel} \u2192 {child.NewModel} (Ano {child.Year})";
+            Console.WriteLine(line);
+            Traverse(child.InheritorCulture, history, indent + 1);
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/EconomicModelInteractionSystem.cs
+++ b/src/UltraWorldAI/Economy/EconomicModelInteractionSystem.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class ModelInteraction
+{
+    public string ModelA { get; set; } = string.Empty;
+    public string ModelB { get; set; } = string.Empty;
+    public string Result { get; set; } = string.Empty;
+    public string InteractionType { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+public static class EconomicModelInteractionSystem
+{
+    public static List<ModelInteraction> Interactions { get; } = new();
+
+    public static void RegisterInteraction(string modelA, string modelB, string type, string result, string description)
+    {
+        Interactions.Add(new ModelInteraction
+        {
+            ModelA = modelA,
+            ModelB = modelB,
+            Result = result,
+            InteractionType = type,
+            Description = description
+        });
+
+        Console.WriteLine($"\uD83D\uDD00 Intera\u00e7\u00e3o registrada: {modelA} x {modelB} \u2192 {result} ({type})");
+    }
+
+    public static void PrintInteractions()
+    {
+        foreach (var i in Interactions)
+        {
+            Console.WriteLine($"\uD83E\uDD01 {i.ModelA} \u00d7 {i.ModelB} | {i.InteractionType} \u2192 {i.Result}");
+            Console.WriteLine($"\uD83D\uDCDD {i.Description}\n");
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/HeirloomEconomySystem.cs
+++ b/src/UltraWorldAI/Economy/HeirloomEconomySystem.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public class EconomicHeirloom
+{
+    public string OriginCulture { get; set; } = string.Empty;
+    public string InheritorCulture { get; set; } = string.Empty;
+    public string OriginalModel { get; set; } = string.Empty;
+    public string NewModel { get; set; } = string.Empty;
+    public string MutationType { get; set; } = string.Empty;
+    public int Year { get; set; }
+}
+
+public static class HeirloomEconomySystem
+{
+    public static List<EconomicHeirloom> History { get; } = new();
+
+    public static void InheritEconomy(string origin, string inheritor, string originalModel, string mutationType, int year)
+    {
+        string newModel = mutationType switch
+        {
+            "Preservado" => originalModel,
+            "Transformado" => TransformModel(originalModel),
+            "Corrompido" => "Dom\u00ednio/Controle",
+            "H\u00edbrido" => $"{originalModel}+Moeda",
+            _ => originalModel
+        };
+
+        History.Add(new EconomicHeirloom
+        {
+            OriginCulture = origin,
+            InheritorCulture = inheritor,
+            OriginalModel = originalModel,
+            NewModel = newModel,
+            MutationType = mutationType,
+            Year = year
+        });
+
+        Console.WriteLine($"\uD83D\uDCDC {inheritor} herdou modelo econ\u00f4mico de {origin} ({mutationType}): {newModel}");
+    }
+
+    private static string TransformModel(string model)
+    {
+        return model switch
+        {
+            "Prest\u00edgio" => "Contrato de Honra",
+            "Ritual" => "Rituais Comerciais",
+            "Moeda" => "Cr\u00e9dito Avan\u00e7ado",
+            "Servi\u00e7o" => "Servid\u00e3o Tempor\u00e1ria",
+            "Barter" => "Troca Vinculada",
+            _ => "Modelo Customizado"
+        };
+    }
+
+    public static void PrintLineage(string culture)
+    {
+        var records = History
+            .Where(h => h.InheritorCulture == culture)
+            .Select(h => $"Ano {h.Year}: Herdou de {h.OriginCulture} ({h.OriginalModel} \u2192 {h.NewModel})")
+            .ToList();
+
+        Console.WriteLine($"\uD83D\uDCD6 Linha econ\u00f4mica de {culture}:\n{string.Join('\n', records)}");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `HeirloomEconomySystem` for tracking inherited trade models
- add `EconomicLineageVisualizer` to print economic genealogies
- create `EconomicModelInteractionSystem` for fusing or conflicting models
- document new features in README

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422a3d6d28832384cb196de042de73