### PR TITLE
Add economic crisis reactions and trade diplomacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **HeirloomEconomySystem** registra legados e mutações de modelos econômicos.
 - **EconomicLineageVisualizer** exibe genealogias econômicas como árvores.
 - **EconomicModelInteractionSystem** documenta fusões e conflitos entre modelos.
+- **EconomicCrisisReactionSystem** faz IAs protestarem ou criarem seitas quando a fé é corrompida ou há injustiça.
+- **TradeDiplomacySystem** coordena tratados comerciais, confiança e traições entre reinos.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **xUnit tests** verificam memórias e resolução de contradições.
 

--- a/src/UltraWorldAI/Economy/EconomicCrisisReactionSystem.cs
+++ b/src/UltraWorldAI/Economy/EconomicCrisisReactionSystem.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class EconomicEmotionProfile
+{
+    public string IAName { get; set; } = string.Empty;
+    public double FaithAlignment { get; set; }
+    public double FairnessNeed { get; set; }
+    public double Aggression { get; set; }
+}
+
+public static class EconomicCrisisReactionSystem
+{
+    public static List<EconomicEmotionProfile> Profiles { get; } = new();
+
+    public static void RegisterIA(string name, double faith, double fairness, double aggression)
+    {
+        Profiles.Add(new EconomicEmotionProfile
+        {
+            IAName = name,
+            FaithAlignment = faith,
+            FairnessNeed = fairness,
+            Aggression = aggression
+        });
+    }
+
+    public static void EvaluateCrisis(string name, bool monetizationOfFaith, bool socialInjustice, bool economicIncompatibility)
+    {
+        var profile = Profiles.Find(p => p.IAName == name);
+        if (profile == null) return;
+
+        if (monetizationOfFaith && profile.FaithAlignment > 0.7)
+        {
+            Console.WriteLine($"\ud83d\ude21 {name} entrou em CRISE DE F\u00c9: f\u00e9 corrompida por com\u00e9rcio!");
+            if (profile.Aggression > 0.5)
+                Console.WriteLine($"\ud83d\udd25 {name} fundou uma seita rebelde contra templos comerciais.");
+        }
+
+        if (socialInjustice && profile.FairnessNeed > 0.6)
+        {
+            Console.WriteLine($"\ud83d\udea8 {name} iniciou protestos por desigualdade econ\u00f4mica.");
+        }
+
+        if (economicIncompatibility && profile.Aggression > 0.6)
+        {
+            Console.WriteLine($"\ud83d\udd01 {name} prop\u00f5e uma REFORMA ECON\u00d4MICA em sua cultura.");
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/TradeDiplomacySystem.cs
+++ b/src/UltraWorldAI/Economy/TradeDiplomacySystem.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public class TradeTreaty
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Members { get; set; } = new();
+    public string Type { get; set; } = string.Empty;
+    public int TrustLevel { get; set; }
+}
+
+public static class TradeDiplomacySystem
+{
+    public static List<TradeTreaty> Treaties { get; } = new();
+
+    public static void CreateTreaty(string name, string type, List<string> members)
+    {
+        Treaties.Add(new TradeTreaty
+        {
+            Name = name,
+            Type = type,
+            Members = new List<string>(members),
+            TrustLevel = 100
+        });
+
+        Console.WriteLine($"\ud83d\udeea Novo tratado comercial criado: {name} ({type})");
+    }
+
+    public static void ModifyTrust(string treatyName, string actor, int delta)
+    {
+        var treaty = Treaties.FirstOrDefault(t => t.Name == treatyName);
+        if (treaty == null || !treaty.Members.Contains(actor)) return;
+
+        treaty.TrustLevel += delta;
+        treaty.TrustLevel = Math.Clamp(treaty.TrustLevel, 0, 100);
+
+        if (treaty.TrustLevel < 30)
+            Console.WriteLine($"\u26a0\ufe0f Confian\u00e7a em {actor} no tratado {treatyName} est\u00e1 em risco: {treaty.TrustLevel}");
+    }
+
+    public static void Betrayal(string treatyName, string betrayer)
+    {
+        var treaty = Treaties.FirstOrDefault(t => t.Name == treatyName);
+        if (treaty == null) return;
+
+        treaty.Members.Remove(betrayer);
+        treaty.TrustLevel -= 25;
+
+        Console.WriteLine($"\ud83d\udc94 {betrayer} traiu o tratado {treatyName}! Confian\u00e7a geral caiu.");
+    }
+
+    public static void PrintTreaties()
+    {
+        foreach (var t in Treaties)
+        {
+            Console.WriteLine($"\ud83c\udf10 Tratado: {t.Name} | Tipo: {t.Type} | Confian\u00e7a: {t.TrustLevel} | Membros: {string.Join(", ", t.Members)}");
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/EconomicDiplomacyTests.cs
+++ b/tests/UltraWorldAI.Tests/EconomicDiplomacyTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class EconomicDiplomacyTests
+{
+    [Fact]
+    public void CrisisReactionOutputsExpectedMessages()
+    {
+        EconomicCrisisReactionSystem.Profiles.Clear();
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        EconomicCrisisReactionSystem.RegisterIA("Kael", 0.9, 0.8, 0.7);
+        EconomicCrisisReactionSystem.EvaluateCrisis("Kael", true, true, true);
+        Console.SetOut(original);
+        var output = writer.ToString();
+        Assert.Contains("CRISE DE FÉ", output);
+        Assert.Contains("protestos", output);
+        Assert.Contains("REFORMA ECONÔMICA", output);
+    }
+
+    [Fact]
+    public void BetrayalRemovesMemberAndAdjustsTrust()
+    {
+        TradeDiplomacySystem.Treaties.Clear();
+        TradeDiplomacySystem.CreateTreaty("Liga", "Livre Comércio", new List<string> { "Aurora", "Umbra" });
+        TradeDiplomacySystem.ModifyTrust("Liga", "Umbra", -40);
+        TradeDiplomacySystem.Betrayal("Liga", "Umbra");
+        var treaty = TradeDiplomacySystem.Treaties.First();
+        Assert.DoesNotContain("Umbra", treaty.Members);
+        Assert.Equal(35, treaty.TrustLevel);
+    }
+}


### PR DESCRIPTION
## Summary
- add **EconomicCrisisReactionSystem** for emotional responses to faith monetization and injustice
- add **TradeDiplomacySystem** to manage trade treaties and betrayal
- document the new systems in README
- test new systems in `EconomicDiplomacyTests`

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68422bc296fc83238489726954fa09c1