### PR TITLE
Add simple game loop and map

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,20 @@
 using UltraWorldAI;
+using UltraWorldAI.Game;
 
 public class Program
 {
     public static void Main(string[] args)
     {
         IA.Initialize();
-        var person = new Person("Demo");
-        person.AddExperience("Started simulation", 0.5f, 0.2f);
-        person.Update();
-        System.Console.WriteLine(person.ReflectOnSelf());
+        var loop = new GameLoop(5, 5);
+        var alice = new Person("Alice");
+        var bob = new Person("Bob");
+        alice.AddExperience("Spawned", 0.4f, 0.1f);
+        bob.AddExperience("Spawned", 0.4f, -0.1f);
+        loop.AddPerson(alice, 2, 2);
+        loop.AddPerson(bob, 1, 1);
+        loop.Run(3);
+        System.Console.WriteLine(alice.ReflectOnSelf());
+        System.Console.WriteLine(bob.ReflectOnSelf());
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ dotnet build src/UltraWorldAI/UltraWorldAI.csproj
 
 Before instantiating any `Person` objects, call `IA.Initialize()` so that runtime settings are loaded from `AIConfig.json`.
 
+### Example Game Loop
+
+The `GameLoop` class provides a very small wrapper to step through multiple `Person` objects on a simple tile map. Create a loop, add characters and run:
+
+```csharp
+IA.Initialize();
+var loop = new GameLoop(5, 5);
+loop.AddPerson(new Person("Alice"), 2, 2);
+loop.AddPerson(new Person("Bob"), 1, 1);
+loop.Run(3);
+```
+
 ## Testing
 
 Run the unit tests with:

--- a/src/UltraWorldAI/Game/GameLoop.cs
+++ b/src/UltraWorldAI/Game/GameLoop.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Game;
+
+public class GameLoop
+{
+    private readonly GameMap _map;
+    private readonly List<(Person person, int x, int y)> _actors = new();
+    private readonly Random _rng = new();
+
+    public GameLoop(int width, int height)
+    {
+        _map = new GameMap(width, height);
+    }
+
+    public void AddPerson(Person person, int x, int y)
+    {
+        _actors.Add((person, x, y));
+        _map.Place(person, x, y);
+    }
+
+    public void Run(int steps)
+    {
+        for (int step = 0; step < steps; step++)
+        {
+            for (int i = 0; i < _actors.Count; i++)
+            {
+                var actor = _actors[i];
+                actor.person.Update();
+                int newX = actor.x + _rng.Next(-1, 2);
+                int newY = actor.y + _rng.Next(-1, 2);
+                newX = Math.Clamp(newX, 0, _map.Width - 1);
+                newY = Math.Clamp(newY, 0, _map.Height - 1);
+                _map.Move(actor.person, actor.x, actor.y, newX, newY);
+                _actors[i] = (actor.person, newX, newY);
+            }
+        }
+    }
+}

--- a/src/UltraWorldAI/Game/GameMap.cs
+++ b/src/UltraWorldAI/Game/GameMap.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Game;
+
+public class Tile
+{
+    public List<Person> Occupants { get; } = new();
+}
+
+public class GameMap
+{
+    private readonly Tile[,] _tiles;
+    public int Width { get; }
+    public int Height { get; }
+
+    public GameMap(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        _tiles = new Tile[width, height];
+        for (int x = 0; x < width; x++)
+        for (int y = 0; y < height; y++)
+            _tiles[x, y] = new Tile();
+    }
+
+    public void Place(Person person, int x, int y)
+    {
+        if (IsInside(x, y))
+            _tiles[x, y].Occupants.Add(person);
+    }
+
+    public void Move(Person person, int fromX, int fromY, int toX, int toY)
+    {
+        if (!IsInside(toX, toY)) return;
+        _tiles[fromX, fromY].Occupants.Remove(person);
+        _tiles[toX, toY].Occupants.Add(person);
+        person.MoveTo($"Tile {toX},{toY}", toX, toY);
+    }
+
+    private bool IsInside(int x, int y) => x >= 0 && y >= 0 && x < Width && y < Height;
+}

--- a/tests/UltraWorldAI.Tests/GameLoopTests.cs
+++ b/tests/UltraWorldAI.Tests/GameLoopTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI;
+using UltraWorldAI.Game;
+using Xunit;
+
+public class GameLoopTests
+{
+    [Fact]
+    public void RunAdvancesActors()
+    {
+        var loop = new GameLoop(3, 3);
+        var a = new Person("A");
+        loop.AddPerson(a, 1, 1);
+        var before = a.Mind.Memory.Memories.Count;
+        loop.Run(2);
+        Assert.True(a.Mind.Memory.Memories.Count >= before);
+    }
+}

--- a/tests/UltraWorldAI.Tests/GameMapTests.cs
+++ b/tests/UltraWorldAI.Tests/GameMapTests.cs
@@ -1,0 +1,16 @@
+using UltraWorldAI;
+using UltraWorldAI.Game;
+using Xunit;
+
+public class GameMapTests
+{
+    [Fact]
+    public void PlaceAndMovePersonUpdatesLocation()
+    {
+        var map = new GameMap(3, 3);
+        var person = new Person("Mover");
+        map.Place(person, 0, 0);
+        map.Move(person, 0, 0, 1, 1);
+        Assert.Equal("Tile 1,1", person.Location.RegionName);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameLoop` and `GameMap` to start a basic simulation loop
- update `Program` to run two characters in the loop
- document small example in README
- add unit tests for the new classes

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68422c08602c832383c9da9a764b5e4d