### PR TITLE
Add pathfinding with obstacles

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,21 @@
 using UltraWorldAI;
+using UltraWorldAI.Game;
 
 public class Program
 {
     public static void Main(string[] args)
     {
         IA.Initialize();
-        var person = new Person("Demo");
-        person.AddExperience("Started simulation", 0.5f, 0.2f);
-        person.Update();
-        System.Console.WriteLine(person.ReflectOnSelf());
+        var loop = new GameLoop(5, 5, true);
+        var alice = new Person("Alice");
+        var bob = new Person("Bob");
+        alice.Inventory.Add(new Item("Key"));
+        alice.AddExperience("Spawned", 0.4f, 0.1f);
+        bob.AddExperience("Spawned", 0.4f, -0.1f);
+        loop.AddPerson(alice, 2, 2);
+        loop.AddPerson(bob, 1, 1);
+        loop.Run(3);
+        System.Console.WriteLine(alice.ReflectOnSelf());
+        System.Console.WriteLine(bob.ReflectOnSelf());
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **EconomicCrisisReactionSystem** faz IAs protestarem ou criarem seitas quando a fé é corrompida ou há injustiça.
 - **TradeDiplomacySystem** coordena tratados comerciais, confiança e traições entre reinos.
 - **Logger** suporta níveis de log e gravação em arquivo.
+- **Inventory system** permite que personagens colecionem `Item`s básicos.
 - **xUnit tests** verificam memórias e resolução de contradições.
 
 ## Building
@@ -54,6 +55,22 @@ dotnet build src/UltraWorldAI/UltraWorldAI.csproj
 ```
 
 Before instantiating any `Person` objects, call `IA.Initialize()` so that runtime settings are loaded from `AIConfig.json`.
+
+### Example Game Loop
+
+The `GameLoop` class provides a very small wrapper to step through multiple `Person` objects on a simple tile map. Create a loop, add characters and run:
+
+```csharp
+IA.Initialize();
+var loop = new GameLoop(5, 5, true);
+var alice = new Person("Alice");
+alice.Inventory.Add(new Item("Key"));
+loop.AddPerson(alice, 2, 2);
+loop.AddPerson(new Person("Bob"), 1, 1);
+loop.Run(3);
+```
+
+`GameMap` supports obstacles using `SetPassable(x, y, false)`. Use `Pathfinding.FindPath` to move toward targets avoiding obstacles.
 
 ## Testing
 

--- a/src/UltraWorldAI/Game/GameLoop.cs
+++ b/src/UltraWorldAI/Game/GameLoop.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Game;
+
+public class GameLoop
+{
+    private readonly GameMap _map;
+    private readonly List<(Person person, int x, int y)> _actors = new();
+    private readonly Random _rng = new();
+    private readonly bool _display;
+
+    public GameLoop(int width, int height, bool display = false)
+    {
+        _map = new GameMap(width, height);
+        _display = display;
+    }
+
+    public void AddPerson(Person person, int x, int y)
+    {
+        _actors.Add((person, x, y));
+        _map.Place(person, x, y);
+    }
+
+    public void Run(int steps)
+    {
+        for (int step = 0; step < steps; step++)
+        {
+            for (int i = 0; i < _actors.Count; i++)
+            {
+                var actor = _actors[i];
+                actor.person.Update();
+                int newX = actor.x + _rng.Next(-1, 2);
+                int newY = actor.y + _rng.Next(-1, 2);
+                newX = Math.Clamp(newX, 0, _map.Width - 1);
+                newY = Math.Clamp(newY, 0, _map.Height - 1);
+                _map.Move(actor.person, actor.x, actor.y, newX, newY);
+                _actors[i] = (actor.person, newX, newY);
+            }
+            if (_display)
+            {
+                Console.WriteLine($"Step {step + 1}\n{_map.Render()}");
+            }
+        }
+    }
+}

--- a/src/UltraWorldAI/Game/GameMap.cs
+++ b/src/UltraWorldAI/Game/GameMap.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Game;
+
+public class Tile
+{
+    public List<Person> Occupants { get; } = new();
+    public bool Passable { get; set; } = true;
+}
+
+public class GameMap
+{
+    private readonly Tile[,] _tiles;
+    public int Width { get; }
+    public int Height { get; }
+
+    public GameMap(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        _tiles = new Tile[width, height];
+        for (int x = 0; x < width; x++)
+        for (int y = 0; y < height; y++)
+            _tiles[x, y] = new Tile();
+    }
+
+    public void SetPassable(int x, int y, bool passable)
+    {
+        if (IsInside(x, y))
+            _tiles[x, y].Passable = passable;
+    }
+
+    public bool IsPassable(int x, int y) => IsInside(x, y) && _tiles[x, y].Passable;
+
+    public void Place(Person person, int x, int y)
+    {
+        if (IsPassable(x, y))
+        {
+            _tiles[x, y].Occupants.Add(person);
+            person.MoveTo($"Tile {x},{y}", x, y);
+        }
+    }
+
+    public void Move(Person person, int fromX, int fromY, int toX, int toY)
+    {
+        if (!IsPassable(toX, toY)) return;
+        _tiles[fromX, fromY].Occupants.Remove(person);
+        _tiles[toX, toY].Occupants.Add(person);
+        person.MoveTo($"Tile {toX},{toY}", toX, toY);
+    }
+
+    public string Render()
+    {
+        var sb = new System.Text.StringBuilder();
+        for (int y = 0; y < Height; y++)
+        {
+            for (int x = 0; x < Width; x++)
+            {
+                if (!_tiles[x, y].Passable)
+                    sb.Append('#');
+                else
+                    sb.Append(_tiles[x, y].Occupants.Count > 0 ? 'O' : '.');
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    private bool IsInside(int x, int y) => x >= 0 && y >= 0 && x < Width && y < Height;
+}

--- a/src/UltraWorldAI/Game/Inventory.cs
+++ b/src/UltraWorldAI/Game/Inventory.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Game;
+
+public class Inventory
+{
+    private readonly List<Item> _items = new();
+    public IReadOnlyList<Item> Items => _items;
+
+    public void Add(Item item) => _items.Add(item);
+    public bool Remove(Item item) => _items.Remove(item);
+}

--- a/src/UltraWorldAI/Game/Item.cs
+++ b/src/UltraWorldAI/Game/Item.cs
@@ -1,0 +1,11 @@
+namespace UltraWorldAI.Game;
+
+public class Item
+{
+    public string Name { get; }
+
+    public Item(string name)
+    {
+        Name = name;
+    }
+}

--- a/src/UltraWorldAI/Game/Pathfinding.cs
+++ b/src/UltraWorldAI/Game/Pathfinding.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Game;
+
+public static class Pathfinding
+{
+    private record Node(int X, int Y, Node? Parent);
+
+    public static List<(int x, int y)> FindPath(GameMap map, int startX, int startY, int endX, int endY)
+    {
+        var visited = new bool[map.Width, map.Height];
+        var queue = new Queue<Node>();
+        queue.Enqueue(new Node(startX, startY, null));
+        visited[startX, startY] = true;
+
+        int[] dirs = { -1, 0, 1 };
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            if (node.X == endX && node.Y == endY)
+                return Reconstruct(node);
+
+            foreach (var dx in dirs)
+            foreach (var dy in dirs)
+            {
+                if (dx == 0 && dy == 0) continue;
+                int nx = node.X + dx;
+                int ny = node.Y + dy;
+                if (!map.IsPassable(nx, ny)) continue;
+                if (visited[nx, ny]) continue;
+                visited[nx, ny] = true;
+                queue.Enqueue(new Node(nx, ny, node));
+            }
+        }
+        return new();
+    }
+
+    private static List<(int x, int y)> Reconstruct(Node node)
+    {
+        var path = new List<(int, int)>();
+        while (node.Parent != null)
+        {
+            path.Insert(0, (node.X, node.Y));
+            node = node.Parent;
+        }
+        return path;
+    }
+}
+

--- a/src/UltraWorldAI/Person.cs
+++ b/src/UltraWorldAI/Person.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UltraWorldAI.Territory;
+using UltraWorldAI.Game;
 
 namespace UltraWorldAI
 {
@@ -9,6 +10,7 @@ namespace UltraWorldAI
         public string Name { get; set; }
         public string Bloodline { get; set; } = string.Empty;
         public Mind Mind { get; private set; }
+        public Inventory Inventory { get; } = new();
         public LifeStage CurrentLifeStage { get; set; } = LifeStage.Adulto;
         public SpatialIdentity Location { get; private set; }
 

--- a/tests/UltraWorldAI.Tests/GameLoopTests.cs
+++ b/tests/UltraWorldAI.Tests/GameLoopTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI;
+using UltraWorldAI.Game;
+using Xunit;
+
+public class GameLoopTests
+{
+    [Fact]
+    public void RunAdvancesActors()
+    {
+        var loop = new GameLoop(3, 3);
+        var a = new Person("A");
+        loop.AddPerson(a, 1, 1);
+        var before = a.Mind.Memory.Memories.Count;
+        loop.Run(2);
+        Assert.True(a.Mind.Memory.Memories.Count >= before);
+    }
+}

--- a/tests/UltraWorldAI.Tests/GameMapRenderTests.cs
+++ b/tests/UltraWorldAI.Tests/GameMapRenderTests.cs
@@ -1,0 +1,16 @@
+using UltraWorldAI;
+using UltraWorldAI.Game;
+using Xunit;
+
+public class GameMapRenderTests
+{
+    [Fact]
+    public void RenderShowsOccupants()
+    {
+        var map = new GameMap(2, 1);
+        var p = new Person("A");
+        map.Place(p, 0, 0);
+        var view = map.Render();
+        Assert.StartsWith("O", view.Trim());
+    }
+}

--- a/tests/UltraWorldAI.Tests/GameMapTests.cs
+++ b/tests/UltraWorldAI.Tests/GameMapTests.cs
@@ -1,0 +1,27 @@
+using UltraWorldAI;
+using UltraWorldAI.Game;
+using Xunit;
+
+public class GameMapTests
+{
+    [Fact]
+    public void PlaceAndMovePersonUpdatesLocation()
+    {
+        var map = new GameMap(3, 3);
+        var person = new Person("Mover");
+        map.Place(person, 0, 0);
+        map.Move(person, 0, 0, 1, 1);
+        Assert.Equal("Tile 1,1", person.Location.RegionName);
+    }
+
+    [Fact]
+    public void CannotMoveIntoObstacle()
+    {
+        var map = new GameMap(2, 1);
+        map.SetPassable(1, 0, false);
+        var p = new Person("B");
+        map.Place(p, 0, 0);
+        map.Move(p, 0, 0, 1, 0);
+        Assert.Equal("Tile 0,0", p.Location.RegionName);
+    }
+}

--- a/tests/UltraWorldAI.Tests/InventoryTests.cs
+++ b/tests/UltraWorldAI.Tests/InventoryTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI;
+using UltraWorldAI.Game;
+using Xunit;
+
+public class InventoryTests
+{
+    [Fact]
+    public void AddItemStoresInInventory()
+    {
+        var person = new Person("Collector");
+        var item = new Item("Coin");
+        person.Inventory.Add(item);
+        Assert.Contains(item, person.Inventory.Items);
+    }
+}

--- a/tests/UltraWorldAI.Tests/PathfindingTests.cs
+++ b/tests/UltraWorldAI.Tests/PathfindingTests.cs
@@ -1,0 +1,25 @@
+using UltraWorldAI.Game;
+using UltraWorldAI;
+using Xunit;
+
+public class PathfindingTests
+{
+    [Fact]
+    public void FindPathReturnsRouteAroundObstacle()
+    {
+        var map = new GameMap(3, 2);
+        map.SetPassable(1, 0, false);
+        var path = Pathfinding.FindPath(map, 0, 0, 2, 0);
+        Assert.True(path.Count > 0);
+        Assert.DoesNotContain((1,0), path);
+    }
+
+    [Fact]
+    public void NoPathReturnsEmptyList()
+    {
+        var map = new GameMap(2, 1);
+        map.SetPassable(1, 0, false);
+        var path = Pathfinding.FindPath(map, 0, 0, 1, 0);
+        Assert.Empty(path);
+    }
+}


### PR DESCRIPTION
## Summary
- add obstacles to `GameMap`
- implement `Pathfinding.FindPath` using BFS
- update map rendering and placement logic
- document map obstacles and pathfinding in README
- add unit tests for new pathfinding and obstacle behavior

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68422c08602c832383c9da9a764b5e4d