### PR TITLE
Add economic ideology conflict and philosophy spread systems

### DIFF
--- a/src/UltraWorldAI/Economy/EconomicIdeologyConflictSystem.cs
+++ b/src/UltraWorldAI/Economy/EconomicIdeologyConflictSystem.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public class IdeologyConflict
+{
+    public string SchoolA { get; init; } = string.Empty;
+    public string SchoolB { get; init; } = string.Empty;
+    public string ConflictType { get; init; } = string.Empty;
+    public int Year { get; init; }
+}
+
+public static class EconomicIdeologyConflictSystem
+{
+    public static List<IdeologyConflict> Conflicts { get; } = new();
+
+    public static void DeclareConflict(string schoolA, string schoolB, string type, int year)
+    {
+        if (Conflicts.Any(c => c.SchoolA == schoolA && c.SchoolB == schoolB && c.ConflictType == type && c.Year == year))
+            return;
+
+        Conflicts.Add(new IdeologyConflict
+        {
+            SchoolA = schoolA,
+            SchoolB = schoolB,
+            ConflictType = type,
+            Year = year
+        });
+
+        Console.WriteLine($"\u2694\ufe0f Conflito declarado entre {schoolA} e {schoolB} ({type}) – Ano {year}");
+    }
+
+    public static void PrintAllConflicts()
+    {
+        foreach (var c in Conflicts)
+            Console.WriteLine($"\ud83d\udd25 {c.SchoolA} vs {c.SchoolB} | Tipo: {c.ConflictType} | Ano: {c.Year}");
+    }
+}

--- a/src/UltraWorldAI/Economy/PhilosophySpreadSystem.cs
+++ b/src/UltraWorldAI/Economy/PhilosophySpreadSystem.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public class SchoolFollower
+{
+    public string Culture { get; set; } = string.Empty;
+    public string School { get; set; } = string.Empty;
+    public double InfluenceLevel { get; set; }
+}
+
+public static class PhilosophySpreadSystem
+{
+    public static List<SchoolFollower> InfluenceMap { get; } = new();
+
+    public static void PropagateToCulture(string school, string culture, double influence)
+    {
+        var entry = InfluenceMap.FirstOrDefault(f => f.Culture == culture && f.School == school);
+        if (entry != null)
+        {
+            entry.InfluenceLevel = Math.Min(100, entry.InfluenceLevel + influence);
+        }
+        else
+        {
+            entry = new SchoolFollower
+            {
+                Culture = culture,
+                School = school,
+                InfluenceLevel = Math.Clamp(influence, 0, 100)
+            };
+            InfluenceMap.Add(entry);
+        }
+
+        Console.WriteLine($"\ud83d\uddE3\ufe0f {school} propagado em {culture} \u2192 Influ\u00eancia atual: {entry.InfluenceLevel:0.0}");
+    }
+
+    public static void SpreadByMissionary(string school, IEnumerable<string> cultures, double intensity)
+    {
+        foreach (var c in cultures)
+            PropagateToCulture(school, c, intensity);
+    }
+
+    public static void PrintInfluenceMap()
+    {
+        foreach (var i in InfluenceMap)
+            Console.WriteLine($"\ud83c\udf0d {i.Culture} segue {i.School} com influ\u00eancia {i.InfluenceLevel:0.0}%");
+    }
+}

--- a/tests/UltraWorldAI.Tests/EconomicIdeologyConflictSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/EconomicIdeologyConflictSystemTests.cs
@@ -1,0 +1,27 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class EconomicIdeologyConflictSystemTests
+{
+    [Fact]
+    public void DeclareConflictAddsEntry()
+    {
+        EconomicIdeologyConflictSystem.Conflicts.Clear();
+        EconomicIdeologyConflictSystem.DeclareConflict("Escola A", "Escola B", "Censura", 1300);
+        Assert.Single(EconomicIdeologyConflictSystem.Conflicts);
+        var c = EconomicIdeologyConflictSystem.Conflicts[0];
+        Assert.Equal("Escola A", c.SchoolA);
+        Assert.Equal("Escola B", c.SchoolB);
+        Assert.Equal("Censura", c.ConflictType);
+        Assert.Equal(1300, c.Year);
+    }
+
+    [Fact]
+    public void DuplicateConflictIsIgnored()
+    {
+        EconomicIdeologyConflictSystem.Conflicts.Clear();
+        EconomicIdeologyConflictSystem.DeclareConflict("A", "B", "Guerra", 1250);
+        EconomicIdeologyConflictSystem.DeclareConflict("A", "B", "Guerra", 1250);
+        Assert.Single(EconomicIdeologyConflictSystem.Conflicts);
+    }
+}

--- a/tests/UltraWorldAI.Tests/PhilosophySpreadSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PhilosophySpreadSystemTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class PhilosophySpreadSystemTests
+{
+    [Fact]
+    public void PropagateIncreasesInfluence()
+    {
+        PhilosophySpreadSystem.InfluenceMap.Clear();
+        PhilosophySpreadSystem.PropagateToCulture("Escola", "Aurora", 30);
+        PhilosophySpreadSystem.PropagateToCulture("Escola", "Aurora", 80);
+        var entry = PhilosophySpreadSystem.InfluenceMap.First(f => f.Culture == "Aurora");
+        Assert.Equal(100, entry.InfluenceLevel);
+    }
+
+    [Fact]
+    public void SpreadByMissionaryAddsCultures()
+    {
+        PhilosophySpreadSystem.InfluenceMap.Clear();
+        PhilosophySpreadSystem.SpreadByMissionary("Escola", new List<string> { "Umbra", "Cinzentos" }, 20);
+        Assert.Equal(2, PhilosophySpreadSystem.InfluenceMap.Count);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EconomicIdeologyConflictSystem` to record conflicts between economic schools
- implement `PhilosophySpreadSystem` to track ideological influence by culture
- add unit tests for both new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68423eb6c71883238cda28f89cc292fa