### PR TITLE
Add stress system tests and procedural export

### DIFF
--- a/src/UltraWorldAI/SymbolicMind.cs
+++ b/src/UltraWorldAI/SymbolicMind.cs
@@ -55,6 +55,20 @@ namespace UltraWorldAI
             ActiveSymbols.RemoveAll(s => s.Intensity < 0.1f);
         }
 
+        /// <summary>
+        /// Converts active symbols to a simple procedural representation.
+        /// </summary>
+        /// <returns>A multi-line string describing each symbol.</returns>
+        public string ToProceduralScript()
+        {
+            var lines = new List<string>();
+            foreach (var symbol in ActiveSymbols)
+            {
+                lines.Add($"SYMBOL {symbol.Archetype.ToUpperInvariant()} MEANS {symbol.Meaning.ToUpperInvariant()};");
+            }
+            return string.Join("\n", lines);
+        }
+
         private static string PickSymbolForEmotion(string emotion)
         {
             return emotion switch

--- a/tests/UltraWorldAI.Tests/StressSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/StressSystemTests.cs
@@ -1,0 +1,40 @@
+using UltraWorldAI;
+using Xunit;
+
+public class StressSystemTests
+{
+    [Fact]
+    public void AddStressIncreasesLevel()
+    {
+        var person = new Person("Stressed");
+        person.Mind.Stress.AddStress(0.3f);
+        Assert.True(person.Mind.Stress.CurrentStressLevel >= 0.3f);
+    }
+
+    [Fact]
+    public void ReduceStressLowersLevel()
+    {
+        var person = new Person("Calm");
+        person.Mind.Stress.AddStress(0.6f);
+        person.Mind.Stress.ReduceStress(0.2f);
+        Assert.InRange(person.Mind.Stress.CurrentStressLevel, 0.3f, 0.5f);
+    }
+
+    [Fact]
+    public void UpdateStressDecayReducesBySettings()
+    {
+        var person = new Person("Decay");
+        person.Mind.Stress.AddStress(0.2f);
+        person.Mind.Stress.UpdateStressDecay();
+        var expected = 0.2f - AISettings.StressDecayRate;
+        Assert.InRange(person.Mind.Stress.CurrentStressLevel, expected - 0.001f, expected + 0.001f);
+    }
+
+    [Fact]
+    public void IsStressedReflectsThreshold()
+    {
+        var person = new Person("Check");
+        person.Mind.Stress.AddStress(0.6f);
+        Assert.True(person.Mind.Stress.IsStressed());
+    }
+}

--- a/tests/UltraWorldAI.Tests/SymbolicMindTests.cs
+++ b/tests/UltraWorldAI.Tests/SymbolicMindTests.cs
@@ -25,4 +25,16 @@ public class SymbolicMindTests
         Assert.Contains(person.Mind.DynamicBeliefs.Beliefs,
             b => b.Statement.Contains("abismo"));
     }
+
+    [Fact]
+    public void ProceduralScriptExportsSymbols()
+    {
+        var person = new Person("Procedural");
+        person.Mind.Emotions.SetEmotion("fear", 0.8f);
+        person.Mind.Symbols.GenerateFromEmotion(person.Mind.Emotions);
+
+        string script = person.Mind.Symbols.ToProceduralScript();
+
+        Assert.Contains("SYMBOL ABISMO MEANS DESCONHECIDO;", script);
+    }
 }


### PR DESCRIPTION
## Summary
- integrate SymbolicMind with a new `ToProceduralScript()` method
- expand tests for SymbolicMind
- add new StressSystem tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842bdeba8888323aaaedef72431aa32