### PR TITLE
Implement civil unrest and crypto trading

### DIFF
--- a/src/UltraWorldAI/BaseTypes.cs
+++ b/src/UltraWorldAI/BaseTypes.cs
@@ -70,12 +70,17 @@ namespace UltraWorldAI
         public static LogLevel Level = LogLevel.Info;
         public static string? FilePath;
 
-        public static void Log(string message, LogLevel level = LogLevel.Info)
+        public static void Log(string message, LogLevel level = LogLevel.Info, Exception? ex = null)
         {
             if (level < Level) return;
-            Console.WriteLine(message);
+            var formatted = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}][{level}] {message}";
+            if (ex != null) formatted += $" Exception: {ex.Message}";
+            Console.WriteLine(formatted);
             if (!string.IsNullOrEmpty(FilePath))
-                File.AppendAllText(FilePath!, message + Environment.NewLine);
+            {
+                File.AppendAllText(FilePath!, formatted + Environment.NewLine);
+                if (ex != null) File.AppendAllText(FilePath!, ex.StackTrace + Environment.NewLine);
+            }
         }
     }
 }

--- a/src/UltraWorldAI/DoctrineSystem.cs
+++ b/src/UltraWorldAI/DoctrineSystem.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace UltraWorldAI
 {
-    public class Doctrine
+    public class SecularDoctrine
     {
         public string Name { get; set; } = string.Empty;
         public List<string> Tenets { get; set; } = new();
@@ -13,7 +13,7 @@ namespace UltraWorldAI
 
     public class DoctrineSystem
     {
-        public List<Doctrine> Doctrines { get; } = new();
+        public List<SecularDoctrine> Doctrines { get; } = new();
         public List<string> CoreTruths { get; } = new();
 
         public void EvolveFromSymbolsAndBeliefs(SymbolicExpressionSystem symbols, BeliefSystem beliefs)
@@ -31,7 +31,7 @@ namespace UltraWorldAI
 
             string truth = $"A verdade é que {string.Join(" e ", values)} são revelações refletidas em {string.Join(", ", meaningfulSymbols)}.";
 
-            var newDoctrine = new Doctrine
+            var newDoctrine = new SecularDoctrine
             {
                 Name = $"Doutrina de {meaningfulSymbols.FirstOrDefault() ?? "origem"}",
                 Tenets = new List<string>

--- a/src/UltraWorldAI/Economy/TradeCareerSystem.cs
+++ b/src/UltraWorldAI/Economy/TradeCareerSystem.cs
@@ -18,12 +18,19 @@ public class TradeGuild
     public double Wealth { get; set; }
 }
 
+public class Cryptocurrency
+{
+    public string Name { get; set; } = string.Empty;
+    public double Value { get; set; }
+}
+
 public class EconomicCareer
 {
     public string Name { get; set; } = string.Empty;
     public string Role { get; set; } = string.Empty; // Mercador, Contrabandista, Banqueiro
     public double Capital { get; set; }
     public string? GuildAffiliation { get; set; }
+    public Dictionary<string, double> CryptoWallet { get; } = new();
 }
 
 public static class TradeCareerSystem
@@ -31,6 +38,7 @@ public static class TradeCareerSystem
     public static List<TradeRoute> Routes { get; } = new();
     public static List<TradeGuild> Guilds { get; } = new();
     public static List<EconomicCareer> ActiveIAs { get; } = new();
+    public static List<Cryptocurrency> Cryptocurrencies { get; } = new();
 
     public static void CreateCareer(string iaName, string role)
     {
@@ -63,5 +71,19 @@ public static class TradeCareerSystem
             Wealth = 1000,
             ControlledSettlements = { initialSettlement }
         });
+    }
+
+    public static void RegisterCryptocurrency(string name, double startingValue)
+    {
+        Cryptocurrencies.Add(new Cryptocurrency { Name = name, Value = startingValue });
+    }
+
+    public static void TradeCrypto(EconomicCareer career, string crypto, double amount)
+    {
+        var currency = Cryptocurrencies.Find(c => c.Name == crypto);
+        if (currency == null) return;
+        if (!career.CryptoWallet.ContainsKey(crypto)) career.CryptoWallet[crypto] = 0;
+        career.CryptoWallet[crypto] += amount;
+        career.Capital -= amount * currency.Value;
     }
 }

--- a/src/UltraWorldAI/Politics/RevoltSystem.cs
+++ b/src/UltraWorldAI/Politics/RevoltSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UltraWorldAI;
 
 namespace UltraWorldAI.Politics;
 
@@ -24,5 +25,16 @@ public static class RevoltSystem
     public static string SimulateFailedRevolt(string leader)
     {
         return $"A tentativa de revolta contra {leader} falhou. Rebeldes caíram ou foram silenciados.";
+    }
+
+    public static string? TriggerCivilUnrest(PowerStructure gov, List<Person> population, string rebelLeader)
+    {
+        if (population.Count == 0) return null;
+        float avg = 0f;
+        foreach (var p in population)
+            avg += p.Mind.Stress.CurrentStressLevel;
+        avg /= population.Count;
+        if (avg < 0.8f) return null;
+        return TriggerRevolt(gov, rebelLeader);
     }
 }

--- a/tests/UltraWorldAI.Tests/CivilUnrestTests.cs
+++ b/tests/UltraWorldAI.Tests/CivilUnrestTests.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class CivilUnrestTests
+{
+    [Fact]
+    public void HighStressTriggersCivilUnrest()
+    {
+        var gov = GovernmentFactory.CreateGovernment("Utopia", GovernmentType.Republica, AuthorityBase.Voto, "Lider", "Centro");
+        var people = new List<Person> { new("A"), new("B") };
+        foreach (var p in people)
+            p.Mind.Stress.AddStress(1f);
+        var result = RevoltSystem.TriggerCivilUnrest(gov, people, "Rebelde");
+        Assert.NotNull(result);
+        Assert.Equal("Rebelde", gov.CurrentLeader);
+    }
+}


### PR DESCRIPTION
## Summary
- expand `Logger` to include timestamps and exception details
- add cryptocurrency support to `TradeCareerSystem`
- introduce `TriggerCivilUnrest` in `RevoltSystem`
- rename `Doctrine` to `SecularDoctrine` to avoid collisions
- test civil unrest trigger

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842c0051cac8323b9b1609517225ec3