### PR TITLE
Add mercantile universities and debate systems

### DIFF
--- a/src/UltraWorldAI/Economy/EconomicUniversitySystem.cs
+++ b/src/UltraWorldAI/Economy/EconomicUniversitySystem.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class EconomicInstitution
+{
+    public string Name { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public string Founder { get; set; } = string.Empty;
+    public List<string> SupportedDoctrines { get; set; } = new();
+    public List<string> InternalFactions { get; set; } = new();
+    public int CulturalInfluence { get; set; }
+}
+
+public static class EconomicUniversitySystem
+{
+    public static List<EconomicInstitution> Institutions { get; } = new();
+
+    public static void CreateInstitution(
+        string name,
+        string location,
+        string founder,
+        IEnumerable<string> doctrines,
+        IEnumerable<string> factions)
+    {
+        var institution = new EconomicInstitution
+        {
+            Name = name,
+            Location = location,
+            Founder = founder,
+            CulturalInfluence = 50,
+            SupportedDoctrines = new List<string>(doctrines),
+            InternalFactions = new List<string>(factions)
+        };
+
+        Institutions.Add(institution);
+        Console.WriteLine($"\ud83c\udfdb\ufe0f Institui\u00e7\u00e3o criada: {name} em {location}, fundado por {founder}");
+    }
+
+    public static void ModifyInfluence(string name, int delta)
+    {
+        var inst = Institutions.Find(i => i.Name == name);
+        if (inst == null) return;
+
+        inst.CulturalInfluence = Math.Clamp(inst.CulturalInfluence + delta, 0, 100);
+        Console.WriteLine($"\ud83d\udcc8 Influ\u00eancia cultural de {name}: {inst.CulturalInfluence}");
+    }
+
+    public static void PrintAll()
+    {
+        foreach (var i in Institutions)
+        {
+            Console.WriteLine($"\n\ud83c\udfeb {i.Name} | Local: {i.Location} | Fundador: {i.Founder}");
+            Console.WriteLine($"\ud83d\udcda Doutrinas: {string.Join(", ", i.SupportedDoctrines)}");
+            Console.WriteLine($"\u2694\ufe0f Fac\u00e7\u00f5es internas: {string.Join(" vs ", i.InternalFactions)}");
+            Console.WriteLine($"\ud83d\udd25 Influ\u00eancia cultural: {i.CulturalInfluence}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Economy/PhilosophicalDebateSystem.cs
+++ b/src/UltraWorldAI/Economy/PhilosophicalDebateSystem.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class PhilosophicalDebate
+{
+    public string Location { get; set; } = string.Empty;
+    public string ParticipantA { get; set; } = string.Empty;
+    public string ParticipantB { get; set; } = string.Empty;
+    public string Topic { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty; // "Vitória A", "Vitória B", etc.
+    public string ResultingChange { get; set; } = string.Empty;
+}
+
+public static class PhilosophicalDebateSystem
+{
+    public static List<PhilosophicalDebate> Debates { get; } = new();
+
+    public static void HostDebate(
+        string location,
+        string participantA,
+        string participantB,
+        string topic,
+        string outcome,
+        string result)
+    {
+        var debate = new PhilosophicalDebate
+        {
+            Location = location,
+            ParticipantA = participantA,
+            ParticipantB = participantB,
+            Topic = topic,
+            Outcome = outcome,
+            ResultingChange = result
+        };
+
+        Debates.Add(debate);
+        Console.WriteLine($"\ud83d\udd0a Debate em {location}: {participantA} vs {participantB} sobre {topic} \u2192 {outcome} ({result})");
+    }
+
+    public static void PrintDebates()
+    {
+        foreach (var d in Debates)
+        {
+            Console.WriteLine($"\n\ud83d\udccd {d.Location} | Tema: {d.Topic}");
+            Console.WriteLine($"\ud83e\udde0 {d.ParticipantA} vs {d.ParticipantB} | Resultado: {d.Outcome}");
+            Console.WriteLine($"\ud83d\udcd8 Mudan\u00e7a: {d.ResultingChange}");
+        }
+    }
+}

--- a/src/UltraWorldAI/RadicalDoctrineEmotionBlocker.cs
+++ b/src/UltraWorldAI/RadicalDoctrineEmotionBlocker.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using UltraWorldAI.Religion;
+using ReligionDoctrine = UltraWorldAI.Religion.Doctrine;
 
 namespace UltraWorldAI;
 
@@ -10,7 +10,7 @@ public class RadicalDoctrineEmotionBlocker
 {
     private readonly HashSet<string> _blockedEmotions = new();
 
-    public void ApplyDoctrine(Doctrine doctrine, IEnumerable<string> emotions)
+    public void ApplyDoctrine(ReligionDoctrine doctrine, IEnumerable<string> emotions)
     {
         if (doctrine.KnownHeresies.Count > 5)
         {

--- a/tests/UltraWorldAI.Tests/EconomicUniversitySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/EconomicUniversitySystemTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class EconomicUniversitySystemTests
+{
+    [Fact]
+    public void CreateInstitutionStoresData()
+    {
+        EconomicUniversitySystem.Institutions.Clear();
+        EconomicUniversitySystem.CreateInstitution(
+            "Biblioteca do Sol",
+            "Aurora",
+            "Kael",
+            new List<string> { "Valor Interno" },
+            new List<string> { "Puristas", "Realistas" });
+
+        Assert.Single(EconomicUniversitySystem.Institutions);
+        var inst = EconomicUniversitySystem.Institutions[0];
+        Assert.Equal("Biblioteca do Sol", inst.Name);
+        Assert.Contains("Puristas", inst.InternalFactions);
+    }
+
+    [Fact]
+    public void ModifyInfluenceClampsBetweenZeroAndHundred()
+    {
+        EconomicUniversitySystem.Institutions.Clear();
+        EconomicUniversitySystem.CreateInstitution(
+            "Templo da Moeda",
+            "Umbra",
+            "Zor'mak",
+            new List<string>(),
+            new List<string>());
+
+        EconomicUniversitySystem.ModifyInfluence("Templo da Moeda", 60);
+        EconomicUniversitySystem.ModifyInfluence("Templo da Moeda", 100);
+
+        var inst = EconomicUniversitySystem.Institutions[0];
+        Assert.Equal(100, inst.CulturalInfluence);
+    }
+}

--- a/tests/UltraWorldAI.Tests/PhilosophicalDebateSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PhilosophicalDebateSystemTests.cs
@@ -1,0 +1,23 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class PhilosophicalDebateSystemTests
+{
+    [Fact]
+    public void HostDebateAddsDebate()
+    {
+        PhilosophicalDebateSystem.Debates.Clear();
+        PhilosophicalDebateSystem.HostDebate(
+            "Salão das Vozes",
+            "Kael",
+            "Zor'mak",
+            "Lucro e Moral",
+            "Vitória A",
+            "Conversão parcial");
+
+        Assert.Single(PhilosophicalDebateSystem.Debates);
+        var debate = PhilosophicalDebateSystem.Debates[0];
+        Assert.Equal("Lucro e Moral", debate.Topic);
+        Assert.Equal("Vitória A", debate.Outcome);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EconomicUniversitySystem` to manage mercantile universities and their influence
- add `PhilosophicalDebateSystem` for debates that shift doctrines
- wire `RadicalDoctrineEmotionBlocker` to reference the Religion Doctrine type explicitly
- test university influence clamping and debate registration

## Testing
- `dotnet build src/UltraWorldAI/UltraWorldAI.csproj -nologo`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo`


------
https://chatgpt.com/codex/tasks/task_e_6842c3cef2608323abc92122e1ff9a84