### PR TITLE
Implement doctrinal lineage and influence modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **EconomicCrisisReactionSystem** faz IAs protestarem ou criarem seitas quando a fé é corrompida ou há injustiça.
 - **HybridDoctrineSystem** mescla economia e filosofia, criando doutrinas híbridas.
 - **PhilosopherLegacySystem** registra filósofos mercantis e suas influências.
+- **DoctrinalPoliticalInfluence** registra reformas e dogmas que impactam reinos.
+- **DoctrinalLineageSystem** mapeia sucessões filosóficas e heresias.
 - **TradeDiplomacySystem** coordena tratados comerciais, confiança e traições entre reinos.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **Inventory system** permite que personagens colecionem `Item`s básicos.

--- a/src/UltraWorldAI/CultureSystem.cs
+++ b/src/UltraWorldAI/CultureSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace UltraWorldAI
 {
@@ -18,7 +19,8 @@ namespace UltraWorldAI
         /// <summary>
         /// Memories shared collectively by members of the culture.
         /// </summary>
-        public MemorySystem CollectiveMemory { get; } = new();
+        [JsonInclude]
+        public MemorySystem CollectiveMemory { get; private set; } = new();
     }
 
     public class Festival

--- a/src/UltraWorldAI/Doctrine/DoctrinalLineageSystem.cs
+++ b/src/UltraWorldAI/Doctrine/DoctrinalLineageSystem.cs
@@ -1,0 +1,45 @@
+namespace UltraWorldAI.Doctrine;
+
+public record DoctrineNode(
+    string Philosopher,
+    string School,
+    string Type,
+    string Successor,
+    int Year);
+
+public static class DoctrinalLineageSystem
+{
+    public static List<DoctrineNode> Lineage { get; } = new();
+
+    public static DoctrineNode AddNode(
+        string philosopher,
+        string school,
+        string type,
+        string successor,
+        int year)
+    {
+        var node = new DoctrineNode(philosopher, school, type, successor, year);
+        Lineage.Add(node);
+        Console.WriteLine($"\uD83D\uDCD8 {philosopher} ({type}) \u2192 {successor} ({school}) – Ano {year}");
+        return node;
+    }
+
+    public static IEnumerable<DoctrineNode> GetSuccessors(string philosopher) =>
+        Lineage.Where(n => n.Philosopher == philosopher);
+
+    public static void PrintLineage(string root)
+    {
+        Console.WriteLine($"\n\uD83C\uDF32 Linhagem doutrinária de {root}:\n");
+        Traverse(root, 0);
+    }
+
+    private static void Traverse(string current, int indent)
+    {
+        foreach (var node in GetSuccessors(current))
+        {
+            Console.WriteLine($"{new string(' ', indent * 2)}→ {node.Successor} ({node.Type}, {node.School}, {node.Year})");
+            Traverse(node.Successor, indent + 1);
+        }
+    }
+}
+

--- a/src/UltraWorldAI/Doctrine/DoctrinalPoliticalInfluence.cs
+++ b/src/UltraWorldAI/Doctrine/DoctrinalPoliticalInfluence.cs
@@ -1,0 +1,40 @@
+namespace UltraWorldAI.Doctrine;
+
+public record DoctrinalInfluence(
+    string Institution,
+    string EventType,
+    string AffectedEntity,
+    string Description,
+    int Year);
+
+public static class DoctrinalPoliticalInfluence
+{
+    public static List<DoctrinalInfluence> Events { get; } = new();
+
+    public static DoctrinalInfluence RegisterInfluence(
+        string institution,
+        string eventType,
+        string target,
+        string description,
+        int year)
+    {
+        var influence = new DoctrinalInfluence(institution, eventType, target, description, year);
+        Events.Add(influence);
+        Console.WriteLine($"\uD83C\uDFDB️ {eventType} registrado: {description} ({target}, ano {year})");
+        return influence;
+    }
+
+    public static IEnumerable<DoctrinalInfluence> GetInfluencesFor(string entity) =>
+        Events.Where(e => e.AffectedEntity == entity);
+
+    public static void PrintInfluence()
+    {
+        foreach (var e in Events)
+        {
+            Console.WriteLine($"\n\uD83D\uDCC5 Ano {e.Year} | \uD83C\uDFEB {e.Institution}");
+            Console.WriteLine($"\uD83D\uDCCC {e.EventType} sobre {e.AffectedEntity}");
+            Console.WriteLine($"\uD83D\uDCDC {e.Description}");
+        }
+    }
+}
+

--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -67,6 +67,7 @@ namespace UltraWorldAI
         /// <summary>
         /// List of all memories known by the agent, ordered from newest to oldest.
         /// </summary>
+        [JsonInclude]
         public List<Memory> Memories { get; private set; } = new List<Memory>();
 
         /// <summary>

--- a/tests/UltraWorldAI.Tests/DoctrinalLineageSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrinalLineageSystemTests.cs
@@ -1,0 +1,18 @@
+using UltraWorldAI.Doctrine;
+using Xunit;
+
+public class DoctrinalLineageSystemTests
+{
+    [Fact]
+    public void AddNodeStoresLineage()
+    {
+        DoctrinalLineageSystem.Lineage.Clear();
+        DoctrinalLineageSystem.AddNode("Kael", "Troca Justa", "Fundador", "Selena", 1259);
+        DoctrinalLineageSystem.AddNode("Selena", "Troca Justa", "Discípula", "Iroren", 1281);
+
+        Assert.Equal(2, DoctrinalLineageSystem.Lineage.Count);
+        var successors = DoctrinalLineageSystem.GetSuccessors("Kael");
+        Assert.Contains(DoctrinalLineageSystem.Lineage[0], successors);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/DoctrinalPoliticalInfluenceTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrinalPoliticalInfluenceTests.cs
@@ -1,0 +1,20 @@
+using UltraWorldAI.Doctrine;
+using Xunit;
+
+public class DoctrinalPoliticalInfluenceTests
+{
+    [Fact]
+    public void RegisterInfluenceStoresEvent()
+    {
+        DoctrinalPoliticalInfluence.Events.Clear();
+        DoctrinalPoliticalInfluence.RegisterInfluence(
+            "Biblioteca do Sol", "Dogma", "Aurora",
+            "Lucro sobre alimentos é pecado", 1270);
+
+        Assert.Single(DoctrinalPoliticalInfluence.Events);
+        var ev = DoctrinalPoliticalInfluence.Events[0];
+        Assert.Equal("Aurora", ev.AffectedEntity);
+        Assert.Contains(ev, DoctrinalPoliticalInfluence.GetInfluencesFor("Aurora"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow `CulturePersistence` to restore collective memories
- mark `MemorySystem.Memories` for JSON serialization
- add `DoctrinalPoliticalInfluence` and `DoctrinalLineageSystem`
- test doctrinal lineage and influence features
- document new doctrinal modules

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_6842c62bbd6083239b12b4ed1a00c422