### PR TITLE
Improve logger and add relic support

### DIFF
--- a/src/UltraWorldAI/BaseTypes.cs
+++ b/src/UltraWorldAI/BaseTypes.cs
@@ -69,7 +69,7 @@ namespace UltraWorldAI
         }
     }
 
-    public enum LogLevel { Debug = 0, Info = 1, Warning = 2 }
+    public enum LogLevel { Debug = 0, Info = 1, Warning = 2, Error = 3 }
 
     public static class Logger
     {
@@ -81,7 +81,14 @@ namespace UltraWorldAI
             if (level < Level) return;
             var formatted = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}][{level}] {message}";
             if (ex != null) formatted += $" Exception: {ex.Message}";
+
+            var color = Console.ForegroundColor;
+            if (level == LogLevel.Error) Console.ForegroundColor = ConsoleColor.Red;
+            else if (level == LogLevel.Warning) Console.ForegroundColor = ConsoleColor.Yellow;
+
             Console.WriteLine(formatted);
+            Console.ForegroundColor = color;
+
             if (!string.IsNullOrEmpty(FilePath))
             {
                 File.AppendAllText(FilePath!, formatted + Environment.NewLine);
@@ -95,7 +102,7 @@ namespace UltraWorldAI
             [System.Runtime.CompilerServices.CallerLineNumber] int line = 0)
         {
             var detail = $"{message} (at {Path.GetFileName(file)}:{line} in {member})";
-            Log(detail, LogLevel.Warning, ex);
+            Log(detail, LogLevel.Error, ex);
         }
     }
 }

--- a/src/UltraWorldAI/Person.cs
+++ b/src/UltraWorldAI/Person.cs
@@ -24,6 +24,7 @@ namespace UltraWorldAI
             Mind = new Mind(this);
             Location = new SpatialIdentity("Origem", 0, 0);
             Age = 0;
+            Religion.RelicSystem.ApplyRelics(this);
         }
 
         public string ReflectOnSelf()

--- a/src/UltraWorldAI/Religion/RelicSystem.cs
+++ b/src/UltraWorldAI/Religion/RelicSystem.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public class Relic
+{
+    public string Name { get; set; } = string.Empty;
+    public string AssociatedBelief { get; set; } = string.Empty;
+    public float Influence { get; set; } = 0.1f;
+}
+
+public static class RelicSystem
+{
+    private static readonly List<Relic> _relics = new();
+
+    public static void AddRelic(string name, string belief, float influence)
+    {
+        _relics.Add(new Relic { Name = name, AssociatedBelief = belief, Influence = influence });
+    }
+
+    public static void ApplyRelics(Person person)
+    {
+        foreach (var relic in _relics)
+        {
+            person.Mind.Beliefs.UpdateBelief(relic.AssociatedBelief, relic.Influence);
+        }
+    }
+}

--- a/src/UltraWorldAI/Visualization/MemoryViewer.cs
+++ b/src/UltraWorldAI/Visualization/MemoryViewer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Visualization;
+
+public static class MemoryViewer
+{
+    public static void Display(IEnumerable<Memory> memories)
+    {
+        Console.WriteLine("\uD83D\uDCCA Memórias");
+        foreach (var mem in memories)
+        {
+            Console.WriteLine($"- [{mem.Date:yyyy-MM-dd}] {mem.Summary} ({mem.Intensity:F2})");
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
@@ -31,4 +31,16 @@ public class ProphecySystemTests
 
         Assert.True(prophecy.IsCorrupted);
     }
+
+    [Fact]
+    public void SelfFulfillmentTriggersWhenMemoryMatches()
+    {
+        var prophecy = ProphecySystem.Create("Visao", "Mago", "fala", "Chave", "Portal aberto");
+        var person = new Person("Profeta");
+        person.AddExperience("Portal aberto", 0.8f);
+
+        ProphecySystem.ApplySelfFulfillment(person.Mind);
+
+        Assert.True(prophecy.IsFulfilled);
+    }
 }


### PR DESCRIPTION
## Summary
- add Error level to `Logger` and color-code console output
- apply relic influences when creating a `Person`
- add `RelicSystem` for belief inheritance
- add `MemoryViewer` helper
- test self-fulfilling prophecies

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ce74b77083239c457dd50da49054