### PR TITLE
Implement reputation guilds and translation layers

### DIFF
--- a/src/UltraWorldAI/DivineBeing.cs
+++ b/src/UltraWorldAI/DivineBeing.cs
@@ -13,7 +13,8 @@ namespace UltraWorldAI
         Fertilidade,
         Tempo,
         Loucura,
-        Reflexo
+        Reflexo,
+        Luz
     }
 
     public enum DivineTemperament
@@ -80,6 +81,7 @@ namespace UltraWorldAI
             if (domain == DivineDomain.Silencio) return "Um vulto sem boca com olhos de pedra.";
             if (domain == DivineDomain.Fogo && temp == DivineTemperament.Vingativo) return "Figura flamejante com olhos vazios.";
             if (domain == DivineDomain.Reflexo) return "Espelho líquido com braços que somem.";
+            if (domain == DivineDomain.Luz) return "Figura radiante envolta em brilho.";
             return "Forma mutável e incompreensível.";
         }
 
@@ -90,6 +92,7 @@ namespace UltraWorldAI
                 DivineDomain.Morte => "Caveira invertida",
                 DivineDomain.Memoria => "Olho costurado",
                 DivineDomain.Sangue => "Círculo quebrado",
+                DivineDomain.Luz => "Raio ascendente",
                 _ => "Símbolo abstrato e ritualístico"
             };
         }

--- a/src/UltraWorldAI/Economy/GuildReputationSystem.cs
+++ b/src/UltraWorldAI/Economy/GuildReputationSystem.cs
@@ -1,0 +1,47 @@
+namespace UltraWorldAI.Economy;
+
+using System.Collections.Generic;
+using System.Linq;
+
+public class GuildReputation
+{
+    public string Guild { get; set; } = string.Empty;
+    public Dictionary<string, float> MemberScores { get; } = new();
+
+    public float Reputation => MemberScores.Count == 0
+        ? 0f
+        : MemberScores.Values.Sum() / MemberScores.Count;
+}
+
+public static class GuildReputationSystem
+{
+    public static List<GuildReputation> Reputations { get; } = new();
+
+    public static void RegisterGuild(string name)
+    {
+        if (Reputations.Any(r => r.Guild == name)) return;
+        Reputations.Add(new GuildReputation { Guild = name });
+    }
+
+    public static void AdjustMemberScore(string guild, string member, float delta)
+    {
+        var rep = Reputations.FirstOrDefault(r => r.Guild == guild);
+        if (rep == null) return;
+        if (!rep.MemberScores.ContainsKey(member)) rep.MemberScores[member] = 0f;
+        rep.MemberScores[member] += delta;
+    }
+
+    public static float GetMemberScore(string guild, string member)
+    {
+        var rep = Reputations.FirstOrDefault(r => r.Guild == guild);
+        if (rep == null) return 0f;
+        return rep.MemberScores.TryGetValue(member, out var val) ? val : 0f;
+    }
+
+    public static float GetGuildReputation(string guild)
+    {
+        var rep = Reputations.FirstOrDefault(r => r.Guild == guild);
+        return rep?.Reputation ?? 0f;
+    }
+}
+

--- a/src/UltraWorldAI/Interface/AIModerationPanel.cs
+++ b/src/UltraWorldAI/Interface/AIModerationPanel.cs
@@ -1,0 +1,25 @@
+namespace UltraWorldAI.Interface;
+
+using System.Collections.Generic;
+using System.Linq;
+
+public class AIModerationPanel
+{
+    private readonly List<Person> _registered = new();
+    private readonly HashSet<string> _blocked = new();
+
+    public void Register(Person person)
+    {
+        if (!_registered.Contains(person))
+            _registered.Add(person);
+    }
+
+    public void Block(string name) => _blocked.Add(name);
+
+    public void Unblock(string name) => _blocked.Remove(name);
+
+    public bool IsBlocked(string name) => _blocked.Contains(name);
+
+    public IEnumerable<Person> ActiveAIs => _registered.Where(p => !_blocked.Contains(p.Name));
+}
+

--- a/src/UltraWorldAI/Language/LanguageEngine.cs
+++ b/src/UltraWorldAI/Language/LanguageEngine.cs
@@ -1,0 +1,32 @@
+namespace UltraWorldAI.Language;
+
+using System.Collections.Generic;
+using System.Linq;
+
+public class TranslationLayer
+{
+    private readonly Dictionary<string, string> _dictionary = new();
+
+    public void AddRule(string original, string translated) => _dictionary[original] = translated;
+
+    public string TranslateWord(string word) => _dictionary.TryGetValue(word, out var val) ? val : word;
+}
+
+public static class LanguageEngine
+{
+    private static readonly List<TranslationLayer> _layers = new();
+
+    public static void Clear() => _layers.Clear();
+
+    public static void AddLayer(TranslationLayer layer) => _layers.Add(layer);
+
+    public static string Translate(string text)
+    {
+        foreach (var layer in _layers)
+        {
+            text = string.Join(' ', text.Split(' ').Select(layer.TranslateWord));
+        }
+        return text;
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/AIModerationPanelTests.cs
+++ b/tests/UltraWorldAI.Tests/AIModerationPanelTests.cs
@@ -1,0 +1,19 @@
+using UltraWorldAI;
+using UltraWorldAI.Interface;
+using Xunit;
+
+public class AIModerationPanelTests
+{
+    [Fact]
+    public void BlockPreventsActiveStatus()
+    {
+        var panel = new AIModerationPanel();
+        var p = new Person("Test");
+        panel.Register(p);
+        panel.Block("Test");
+
+        Assert.Empty(panel.ActiveAIs);
+        Assert.True(panel.IsBlocked("Test"));
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/GuildReputationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/GuildReputationSystemTests.cs
@@ -1,0 +1,19 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class GuildReputationSystemTests
+{
+    [Fact]
+    public void RegisterAndReputationWorks()
+    {
+        GuildReputationSystem.Reputations.Clear();
+        GuildReputationSystem.RegisterGuild("Mercadores");
+        GuildReputationSystem.AdjustMemberScore("Mercadores", "Alice", 5);
+        GuildReputationSystem.AdjustMemberScore("Mercadores", "Bob", -1);
+
+        Assert.Single(GuildReputationSystem.Reputations);
+        Assert.Equal(2, GuildReputationSystem.Reputations[0].MemberScores.Count);
+        Assert.Equal(2f, GuildReputationSystem.GetGuildReputation("Mercadores"));
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/LanguageEngineTests.cs
+++ b/tests/UltraWorldAI.Tests/LanguageEngineTests.cs
@@ -1,0 +1,21 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class LanguageEngineTests
+{
+    [Fact]
+    public void LayersTranslateSequentially()
+    {
+        LanguageEngine.Clear();
+        var layer1 = new TranslationLayer();
+        layer1.AddRule("hello", "hola");
+        var layer2 = new TranslationLayer();
+        layer2.AddRule("hola", "bonjour");
+        LanguageEngine.AddLayer(layer1);
+        LanguageEngine.AddLayer(layer2);
+
+        var result = LanguageEngine.Translate("hello world");
+        Assert.Equal("bonjour world", result);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
@@ -1,3 +1,4 @@
+using UltraWorldAI;
 using UltraWorldAI.Religion;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- extend `DivineDomain` with `Luz` and handle appearance/symbol
- add economic guild reputation tracking
- implement automatic translation layers in `LanguageEngine`
- provide an AI moderation panel interface
- fix Prophecy system test namespace
- test new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842dad03de08323a6de45238acbf1fb