### PR TITLE
Add maritime trade and archaeology features

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ interlinked systems that model memory, beliefs, personality, emotions and more.
 - **DoctrinalPoliticalInfluence** registra reformas e dogmas que impactam reinos.
 - **DoctrinalLineageSystem** mapeia sucessões filosóficas e heresias.
 - **TradeDiplomacySystem** coordena tratados comerciais, confiança e traições entre reinos.
+- **MaritimeTradeSystem** gerencia portos e rotas de comércio naval.
+- **RuinGenerator** e **ArchaeologySystem** criam ruínas e possibilitam exploração arqueológica.
+- **LifeCycleSystem** acompanha nascimento, envelhecimento e morte dos personagens.
+- **HistoricalInspirationSystem** fornece eventos reais para inspiração narrativa.
+- **NarrativeWebPlatform** permite compartilhar narrativas geradas via HTTP.
 - **Logger** suporta níveis de log e gravação em arquivo.
 - **Inventory system** permite que personagens colecionem `Item`s básicos.
 - **xUnit tests** verificam memórias e resolução de contradições.

--- a/src/UltraWorldAI/Economy/MaritimeTradeSystem.cs
+++ b/src/UltraWorldAI/Economy/MaritimeTradeSystem.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public class Port
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+public class NavalRoute
+{
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public int Distance { get; set; }
+    public List<string> Goods { get; } = new();
+}
+
+public static class MaritimeTradeSystem
+{
+    public static List<Port> Ports { get; } = new();
+    public static List<NavalRoute> Routes { get; } = new();
+    private static readonly Random _rng = new();
+
+    public static void RegisterPort(string name)
+    {
+        if (!Ports.Any(p => p.Name == name))
+            Ports.Add(new Port { Name = name });
+    }
+
+    public static NavalRoute AddRoute(string from, string to, int distance)
+    {
+        var route = new NavalRoute { From = from, To = to, Distance = distance };
+        Routes.Add(route);
+        return route;
+    }
+
+    public static float SimulateVoyage(NavalRoute route, string good, float baseValue)
+    {
+        route.Goods.Add(good);
+        var distanceFactor = 1f + route.Distance / 100f;
+        var random = 0.5f + (float)_rng.NextDouble();
+        return baseValue * distanceFactor * random;
+    }
+}

--- a/src/UltraWorldAI/HistoricalInspirationSystem.cs
+++ b/src/UltraWorldAI/HistoricalInspirationSystem.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI;
+
+public static class HistoricalInspirationSystem
+{
+    private static readonly List<string> _events = new()
+    {
+        "A queda do Império Romano",
+        "A descoberta do Brasil",
+        "A Revolução Francesa",
+        "A expedição de Magalhães"
+    };
+
+    private static readonly Random _rand = new();
+
+    public static string GetRandomEvent() => _events[_rand.Next(_events.Count)];
+}

--- a/src/UltraWorldAI/Interface/NarrativeWebPlatform.cs
+++ b/src/UltraWorldAI/Interface/NarrativeWebPlatform.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace UltraWorldAI.Interface;
+
+public class NarrativeEntry
+{
+    public string Name { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+}
+
+public class NarrativeWebPlatform : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly ConcurrentBag<NarrativeEntry> _entries = new();
+    private bool _running;
+
+    public int Port { get; }
+
+    public NarrativeWebPlatform(int port = 8080)
+    {
+        Port = port;
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"http://localhost:{port}/");
+    }
+
+    public void Start()
+    {
+        if (_running) return;
+        _running = true;
+        _listener.Start();
+        Task.Run(HandleAsync);
+    }
+
+    private async Task HandleAsync()
+    {
+        while (_running)
+        {
+            var ctx = await _listener.GetContextAsync();
+            if (ctx.Request.HttpMethod == "POST" && ctx.Request.Url?.AbsolutePath == "/narratives")
+            {
+                using var reader = new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                var json = await reader.ReadToEndAsync();
+                var entry = JsonSerializer.Deserialize<NarrativeEntry>(json);
+                if (entry != null) _entries.Add(entry);
+                ctx.Response.StatusCode = 200;
+                ctx.Response.Close();
+            }
+            else if (ctx.Request.HttpMethod == "GET" && ctx.Request.Url?.AbsolutePath == "/narratives")
+            {
+                var data = JsonSerializer.Serialize(_entries);
+                var buffer = Encoding.UTF8.GetBytes(data);
+                ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            }
+            else
+            {
+                ctx.Response.StatusCode = 404;
+                ctx.Response.Close();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _running = false;
+        if (_listener.IsListening)
+            _listener.Stop();
+        _listener.Close();
+    }
+}

--- a/src/UltraWorldAI/LifeCycleSystem.cs
+++ b/src/UltraWorldAI/LifeCycleSystem.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace UltraWorldAI;
+
+public static class LifeCycleSystem
+{
+    public static void Advance(Person person)
+    {
+        person.Age++;
+        person.CurrentLifeStage = person.Age switch
+        {
+            < 3 => LifeStage.Infantil,
+            < 12 => LifeStage.Crianca,
+            < 18 => LifeStage.Adolescente,
+            < 60 => LifeStage.Adulto,
+            _ => LifeStage.Idoso
+        };
+        if (person.Age >= 80 && person.IsAlive)
+            person.Die();
+    }
+}

--- a/src/UltraWorldAI/Person.cs
+++ b/src/UltraWorldAI/Person.cs
@@ -16,13 +16,17 @@ namespace UltraWorldAI
         public SpatialIdentity Location { get; private set; }
         public Genome Genome { get; set; } = new();
         public int Age { get; set; }
+        public DateTime BirthDate { get; }
+        public DateTime? DeathDate { get; private set; }
+        public bool IsAlive => DeathDate == null;
 
-        public Person(string name, string bloodline = "")
+        public Person(string name, string bloodline = "", DateTime? birthDate = null)
         {
             Name = name;
             Bloodline = bloodline;
             Mind = new Mind(this);
             Location = new SpatialIdentity("Origem", 0, 0);
+            BirthDate = birthDate ?? DateTime.Now;
             Age = 0;
             Religion.RelicSystem.ApplyRelics(this);
         }
@@ -53,10 +57,17 @@ namespace UltraWorldAI
             Location.MoveTo(region, x, y);
         }
 
+        public void Die()
+        {
+            if (DeathDate != null) return;
+            DeathDate = DateTime.Now;
+            Mind.History.RegisterEvent("Morreu");
+        }
+
         public void Update()
         {
             Mind.Update();
-            Age++;
+            LifeCycleSystem.Advance(this);
             PersonalityLifeAdjuster.Apply(this);
         }
 

--- a/src/UltraWorldAI/World/Archaeology/RuinGenerator.cs
+++ b/src/UltraWorldAI/World/Archaeology/RuinGenerator.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace UltraWorldAI.World.Archaeology;
+
+public class Ruin
+{
+    public string Region { get; set; } = string.Empty;
+    public int Age { get; set; }
+    public int LootQuality { get; set; }
+}
+
+public static class RuinGenerator
+{
+    private static readonly Random _rand = new();
+    public static Ruin Generate(string region)
+    {
+        return new Ruin
+        {
+            Region = region,
+            Age = _rand.Next(100, 1000),
+            LootQuality = _rand.Next(1, 100)
+        };
+    }
+}
+
+public static class ArchaeologySystem
+{
+    public static string Explore(Ruin ruin, Person explorer)
+    {
+        var artifact = $"Artefato de {ruin.Region} ({ruin.Age} anos)";
+        explorer.AddExperience($"Explorou ruínas em {ruin.Region}", 0.7f, 0.2f, new() { "arqueologia" });
+        return artifact;
+    }
+}

--- a/tests/UltraWorldAI.Tests/ArchaeologySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ArchaeologySystemTests.cs
@@ -1,0 +1,16 @@
+using UltraWorldAI;
+using UltraWorldAI.World.Archaeology;
+using Xunit;
+
+public class ArchaeologySystemTests
+{
+    [Fact]
+    public void ExplorationAddsMemory()
+    {
+        var ruin = RuinGenerator.Generate("Vale Perdido");
+        var person = new Person("Explorer");
+        var artifact = ArchaeologySystem.Explore(ruin, person);
+        Assert.Contains("ruínas", person.Mind.Memory.Memories[0].Summary);
+        Assert.Contains("Artefato", artifact);
+    }
+}

--- a/tests/UltraWorldAI.Tests/HistoricalInspirationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/HistoricalInspirationSystemTests.cs
@@ -1,0 +1,12 @@
+using UltraWorldAI;
+using Xunit;
+
+public class HistoricalInspirationSystemTests
+{
+    [Fact]
+    public void ReturnsNonEmptyEvent()
+    {
+        var e = HistoricalInspirationSystem.GetRandomEvent();
+        Assert.False(string.IsNullOrEmpty(e));
+    }
+}

--- a/tests/UltraWorldAI.Tests/LifeCycleSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LifeCycleSystemTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI;
+using Xunit;
+
+public class LifeCycleSystemTests
+{
+    [Fact]
+    public void PersonDiesAfterEightyYears()
+    {
+        var p = new Person("Idoso");
+        p.Age = 79;
+        LifeCycleSystem.Advance(p);
+        Assert.True(p.IsAlive);
+        LifeCycleSystem.Advance(p); // 80
+        Assert.False(p.IsAlive);
+        Assert.NotNull(p.DeathDate);
+    }
+}

--- a/tests/UltraWorldAI.Tests/MaritimeTradeSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MaritimeTradeSystemTests.cs
@@ -1,0 +1,18 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class MaritimeTradeSystemTests
+{
+    [Fact]
+    public void VoyageGeneratesProfit()
+    {
+        MaritimeTradeSystem.Ports.Clear();
+        MaritimeTradeSystem.Routes.Clear();
+        MaritimeTradeSystem.RegisterPort("PortoA");
+        MaritimeTradeSystem.RegisterPort("PortoB");
+        var route = MaritimeTradeSystem.AddRoute("PortoA", "PortoB", 200);
+        var value = MaritimeTradeSystem.SimulateVoyage(route, "Peixe", 10f);
+        Assert.True(value > 0);
+        Assert.Contains("Peixe", route.Goods);
+    }
+}

--- a/tests/UltraWorldAI.Tests/NarrativeWebPlatformTests.cs
+++ b/tests/UltraWorldAI.Tests/NarrativeWebPlatformTests.cs
@@ -1,0 +1,22 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using UltraWorldAI.Interface;
+using Xunit;
+
+public class NarrativeWebPlatformTests
+{
+    [Fact]
+    public async Task ServerStoresNarratives()
+    {
+        using var server = new NarrativeWebPlatform(18080);
+        server.Start();
+        using var client = new HttpClient();
+        var entry = new NarrativeEntry { Name = "Teste", Text = "Algo" };
+        var content = new StringContent(JsonSerializer.Serialize(entry), Encoding.UTF8, "application/json");
+        await client.PostAsync("http://localhost:18080/narratives", content);
+        var json = await client.GetStringAsync("http://localhost:18080/narratives");
+        Assert.Contains("Algo", json);
+    }
+}


### PR DESCRIPTION
## Summary
- add MaritimeTradeSystem for naval routes
- implement ArchaeologySystem with ruin generation
- include HistoricalInspirationSystem for real events
- add LifeCycleSystem and update Person for birth and death
- provide NarrativeWebPlatform HTTP server
- document new systems
- test new functionality

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dda09cb483238406e6b86ceb6b44