### PR TITLE
Implement additional world systems

### DIFF
--- a/src/UltraWorldAI/Civilization/CulturalInfluenceAnalyzer.cs
+++ b/src/UltraWorldAI/Civilization/CulturalInfluenceAnalyzer.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+
+namespace UltraWorldAI.Civilization;
+
+public static class CulturalInfluenceAnalyzer
+{
+    public static double CalculateInfluence(string fromRace, string toRace)
+    {
+        var from = RaceCultureSystem.GetForRace(fromRace);
+        var to = RaceCultureSystem.GetForRace(toRace);
+        if (from == null || to == null) return 0;
+        double shared = from.PreferredProfessions.Intersect(to.PreferredProfessions).Count();
+        double total = from.PreferredProfessions.Union(to.PreferredProfessions).Count();
+        return total == 0 ? 0 : shared / total;
+    }
+}

--- a/src/UltraWorldAI/Economy/IndustrialEspionageSystem.cs
+++ b/src/UltraWorldAI/Economy/IndustrialEspionageSystem.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public static class IndustrialEspionageSystem
+{
+    private static readonly Dictionary<string, List<string>> _stolen = new();
+
+    public static void Steal(string thief, string target, string technology)
+    {
+        string key = $"{thief}->{target}";
+        if (!_stolen.ContainsKey(key))
+            _stolen[key] = new();
+        _stolen[key].Add(technology);
+        Logger.Log($"[Espionagem] {thief} roubou {technology} de {target}", LogLevel.Info);
+    }
+
+    public static IReadOnlyList<string> GetStolen(string thief, string target)
+    {
+        string key = $"{thief}->{target}";
+        return _stolen.GetValueOrDefault(key) ?? new List<string>();
+    }
+}

--- a/src/UltraWorldAI/LifeCycleSystem.cs
+++ b/src/UltraWorldAI/LifeCycleSystem.cs
@@ -15,7 +15,7 @@ public static class LifeCycleSystem
             < 60 => LifeStage.Adulto,
             _ => LifeStage.Idoso
         };
-        if (person.Age >= 80 && person.IsAlive)
+        if (person.Age > 80 && person.IsAlive)
             person.Die();
     }
 }

--- a/src/UltraWorldAI/Politics/IntergalacticDiplomacyAI.cs
+++ b/src/UltraWorldAI/Politics/IntergalacticDiplomacyAI.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace UltraWorldAI.Politics;
+
+public static class IntergalacticDiplomacyAI
+{
+    public static DiplomaticRelation Evaluate(string factionA, int powerA, string factionB, int powerB)
+    {
+        int diff = Math.Abs(powerA - powerB);
+        if (diff < 10) return DiplomaticRelation.Aliança;
+        return powerA > powerB ? DiplomaticRelation.Desconfiança : DiplomaticRelation.Guerra;
+    }
+}

--- a/src/UltraWorldAI/Politics/MassManipulationSystem.cs
+++ b/src/UltraWorldAI/Politics/MassManipulationSystem.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public static class MassManipulationSystem
+{
+    private static readonly Dictionary<string, float> _influence = new();
+
+    public static void Propagate(string population, string message, float intensity)
+    {
+        if (!_influence.ContainsKey(population))
+            _influence[population] = 0f;
+        _influence[population] += intensity;
+        Logger.Log($"[Propaganda] {message} aplicado em {population}", LogLevel.Info);
+    }
+
+    public static float GetInfluence(string population) => _influence.GetValueOrDefault(population);
+}

--- a/src/UltraWorldAI/Politics/PoliticalEvolutionTracker.cs
+++ b/src/UltraWorldAI/Politics/PoliticalEvolutionTracker.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Politics;
+
+public record PoliticalEra(string Kingdom, int StartYear, int EndYear, GovernmentType GovernmentType);
+
+public static class PoliticalEvolutionTracker
+{
+    private static readonly List<PoliticalEra> _history = new();
+
+    public static void AddEra(string kingdom, int startYear, int endYear, GovernmentType type)
+    {
+        _history.Add(new PoliticalEra(kingdom, startYear, endYear, type));
+    }
+
+    public static IEnumerable<PoliticalEra> HistoryOf(string kingdom)
+    {
+        return _history.Where(e => e.Kingdom == kingdom).OrderBy(e => e.StartYear);
+    }
+}

--- a/src/UltraWorldAI/Politics/War/RealTimeBattleAI.cs
+++ b/src/UltraWorldAI/Politics/War/RealTimeBattleAI.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace UltraWorldAI.Politics.War;
+
+public static class RealTimeBattleAI
+{
+    public static string SimulateBattle(string attacker, double attackerStrength, string defender, double defenderStrength)
+    {
+        var rand = new Random();
+        double tacticalFactor = rand.NextDouble() * 0.2 - 0.1; // -0.1 a 0.1
+        attackerStrength += attackerStrength * tacticalFactor;
+        defenderStrength += defenderStrength * -tacticalFactor;
+        return attackerStrength >= defenderStrength ? attacker : defender;
+    }
+}

--- a/src/UltraWorldAI/World/BuildingUpgradeSystem.cs
+++ b/src/UltraWorldAI/World/BuildingUpgradeSystem.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public static class BuildingUpgradeSystem
+{
+    private static readonly Dictionary<(string settlement, string building), int> _levels = new();
+
+    public static void Upgrade(string settlement, string building)
+    {
+        var key = (settlement, building);
+        _levels[key] = _levels.GetValueOrDefault(key) + 1;
+        SettlementHistoryTracker.Register(settlement, "Upgrade", $"{building} nível {_levels[key]}");
+    }
+
+    public static int GetLevel(string settlement, string building) => _levels.GetValueOrDefault((settlement, building));
+}

--- a/src/UltraWorldAI/World/Ecology/DynamicWeatherEconomy.cs
+++ b/src/UltraWorldAI/World/Ecology/DynamicWeatherEconomy.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World.Ecology;
+
+public static class DynamicWeatherEconomy
+{
+    private static readonly Dictionary<string, double> _yields = new();
+
+    public static void RegisterRegion(string region, double baseYield)
+    {
+        _yields[region] = baseYield;
+    }
+
+    public static void ApplyWeatherEvent(string region, ClimateEvent evt)
+    {
+        if (!_yields.ContainsKey(region)) return;
+        double modifier = evt.Type switch
+        {
+            "Seca" => -0.3,
+            "Furacao" => -0.2,
+            "Tempestade" => -0.1,
+            "Chuva" => 0.1,
+            "Nevasca" => -0.15,
+            _ => 0
+        };
+        _yields[region] += _yields[region] * modifier;
+        MapFaithEconomyIntegration.UpdateNodeWealth(region, _yields[region] * modifier);
+    }
+
+    public static double GetYield(string region) => _yields.GetValueOrDefault(region);
+}

--- a/src/UltraWorldAI/World/ResourceConsumptionTracker.cs
+++ b/src/UltraWorldAI/World/ResourceConsumptionTracker.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public static class ResourceConsumptionTracker
+{
+    private static readonly Dictionary<string, double> _resources = new();
+
+    public static void Register(string settlement, double amount)
+    {
+        _resources[settlement] = amount;
+    }
+
+    public static void Consume(string settlement, double amount)
+    {
+        if (!_resources.ContainsKey(settlement)) return;
+        _resources[settlement] = System.Math.Max(0, _resources[settlement] - amount);
+        double impact = amount * 0.05;
+        MapFaithEconomyIntegration.UpdateNodeWealth(settlement, -impact);
+    }
+
+    public static double GetRemaining(string settlement) => _resources.GetValueOrDefault(settlement);
+}


### PR DESCRIPTION
## Summary
- fix LifeCycleSystem death condition for age 81
- add PoliticalEvolutionTracker for monitoring government eras
- include MassManipulationSystem for propaganda effects
- create RealTimeBattleAI for simple tactical resolution
- add DynamicWeatherEconomy to link climate and wealth
- provide CulturalInfluenceAnalyzer for races
- add BuildingUpgradeSystem, IndustrialEspionageSystem, IntergalacticDiplomacyAI
- add ResourceConsumptionTracker for natural resources
- ensure tests pass

## Testing
- `dotnet build -c Release`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842e64d29188323a463b3713e97b441