### PR TITLE
Implement myth and policy modules

### DIFF
--- a/src/UltraWorldAI/Economy/TaxPolicySystem.cs
+++ b/src/UltraWorldAI/Economy/TaxPolicySystem.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class TaxPolicy
+{
+    public string Settlement { get; set; } = string.Empty;
+    public double Rate { get; set; }
+    public string Policy { get; set; } = "geral";
+}
+
+public static class TaxPolicySystem
+{
+    private static readonly Dictionary<string, TaxPolicy> _policies = new();
+
+    public static void SetTax(string settlement, double rate, string policy = "geral")
+    {
+        _policies[settlement] = new TaxPolicy { Settlement = settlement, Rate = rate, Policy = policy };
+    }
+
+    public static double GetTaxRate(string settlement)
+    {
+        return _policies.TryGetValue(settlement, out var p) ? p.Rate : 0.0;
+    }
+
+    public static double ApplyTax(string settlement, double amount)
+    {
+        return amount * GetTaxRate(settlement);
+    }
+}

--- a/src/UltraWorldAI/LifeCycleSystem.cs
+++ b/src/UltraWorldAI/LifeCycleSystem.cs
@@ -15,7 +15,7 @@ public static class LifeCycleSystem
             < 60 => LifeStage.Adulto,
             _ => LifeStage.Idoso
         };
-        if (person.Age >= 80 && person.IsAlive)
+        if (person.Age > 80 && person.IsAlive)
             person.Die();
     }
 }

--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -79,7 +79,7 @@ namespace UltraWorldAI
         /// <param name="emotionalCharge">Associated emotional valence.</param>
         /// <param name="keywords">Optional keywords for retrieval.</param>
         /// <param name="source">Source of the experience.</param>
-        public void AddMemory(string summary, float intensity = 0.5f, float emotionalCharge = 0.0f, List<string>? keywords = null, string source = "self", string emotion = "")
+        public virtual void AddMemory(string summary, float intensity = 0.5f, float emotionalCharge = 0.0f, List<string>? keywords = null, string source = "self", string emotion = "")
         {
             if (Memories.Count >= AISettings.MaxMemories)
             {
@@ -115,7 +115,7 @@ namespace UltraWorldAI
         /// Applies decay to all memories and removes those that fall below the
         /// configured threshold.
         /// </summary>
-        public void UpdateMemoryDecay()
+        public virtual void UpdateMemoryDecay()
         {
             var threshold = AIConfig.ForgottenMemoryThreshold;
             foreach (var mem in Memories)

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -54,10 +54,10 @@ namespace UltraWorldAI
 
         public Territory.HabitatMemory HabitatMemory { get; private set; }
         public Language.NeuralLanguageLearner LanguageLearner { get; private set; }
-        public Mind(Person person)
+        public Mind(Person person, MemorySystem? memory = null)
         {
             PersonReference = person;
-            Memory = new MemorySystem();
+            Memory = memory ?? new MemorySystem();
             Beliefs = new BeliefSystem();
             DynamicBeliefs = new BeliefArchitecture();
             Personality = new PersonalitySystem();

--- a/src/UltraWorldAI/Mythology/MythGenerator.cs
+++ b/src/UltraWorldAI/Mythology/MythGenerator.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace UltraWorldAI.Mythology;
+
+/// <summary>
+/// Generates short procedural legends and myths.
+/// </summary>
+public static class MythGenerator
+{
+    private static readonly string[] Heroes = { "Arion", "Belthar", "Celes", "Darian", "Eldric" };
+    private static readonly string[] Creatures =
+        { "drag\u00e3o", "esp\u00edrito ancestral", "tit\u00e3 do fogo", "ser da floresta", "deus esquecido" };
+    private static readonly string[] Quests =
+        { "buscou a chama eterna", "desafiou a f\u00faria do mar", "selou o portal proibido", "traiu os pr\u00f3prios irm\u00e3os", "encontrou a fonte da vida" };
+
+    public static string GenerateLegend()
+    {
+        var hero = Heroes[Random.Shared.Next(Heroes.Length)];
+        var creature = Creatures[Random.Shared.Next(Creatures.Length)];
+        var quest = Quests[Random.Shared.Next(Quests.Length)];
+        return $"\uD83D\uDCDC Lenda de {hero}, que enfrentou um {creature} e {quest}.";
+    }
+}

--- a/src/UltraWorldAI/Person.cs
+++ b/src/UltraWorldAI/Person.cs
@@ -11,6 +11,7 @@ namespace UltraWorldAI
         public string Name { get; set; }
         public string Bloodline { get; set; } = string.Empty;
         public Mind Mind { get; private set; }
+        public bool HasPhotographicMemory { get; }
         public Inventory Inventory { get; } = new();
         public LifeStage CurrentLifeStage { get; set; } = LifeStage.Adulto;
         public SpatialIdentity Location { get; private set; }
@@ -20,11 +21,12 @@ namespace UltraWorldAI
         public DateTime? DeathDate { get; private set; }
         public bool IsAlive => DeathDate == null;
 
-        public Person(string name, string bloodline = "", DateTime? birthDate = null)
+        public Person(string name, string bloodline = "", DateTime? birthDate = null, bool photographicMemory = false)
         {
             Name = name;
             Bloodline = bloodline;
-            Mind = new Mind(this);
+            Mind = new Mind(this, photographicMemory ? new PhotographicMemorySystem() : null);
+            HasPhotographicMemory = photographicMemory;
             Location = new SpatialIdentity("Origem", 0, 0);
             BirthDate = birthDate ?? DateTime.Now;
             Age = 0;

--- a/src/UltraWorldAI/PhotographicMemorySystem.cs
+++ b/src/UltraWorldAI/PhotographicMemorySystem.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI;
+
+/// <summary>
+/// Memory system that does not forget experiences and preserves intensity.
+/// </summary>
+public class PhotographicMemorySystem : MemorySystem
+{
+    /// <inheritdoc />
+    public override void AddMemory(string summary, float intensity = 0.5f, float emotionalCharge = 0.0f,
+        List<string>? keywords = null, string source = "self", string emotion = "")
+    {
+        Memories.Add(new Memory
+        {
+            Summary = summary,
+            Date = DateTime.Now,
+            Intensity = Math.Clamp(intensity, 0f, 1f),
+            EmotionalCharge = Math.Clamp(emotionalCharge, -1f, 1f),
+            Keywords = keywords ?? new List<string>(),
+            Source = source,
+            Emotion = emotion
+        });
+        Memories.Sort((a, b) => b.Date.CompareTo(a.Date));
+    }
+
+    /// <inheritdoc />
+    public override void UpdateMemoryDecay()
+    {
+        // Photographic memory retains full intensity and never discards memories.
+    }
+}

--- a/src/UltraWorldAI/Politics/CorruptionSystem.cs
+++ b/src/UltraWorldAI/Politics/CorruptionSystem.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class CorruptionCase
+{
+    public string Suspect { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public bool Investigated { get; set; }
+    public bool Proven { get; set; }
+}
+
+public static class CorruptionSystem
+{
+    public static List<CorruptionCase> Cases { get; } = new();
+
+    public static CorruptionCase ReportCase(string suspect, string description)
+    {
+        var c = new CorruptionCase { Suspect = suspect, Description = description };
+        Cases.Add(c);
+        return c;
+    }
+
+    public static void InvestigateAll()
+    {
+        foreach (var c in Cases)
+        {
+            if (c.Investigated) continue;
+            c.Investigated = true;
+            c.Proven = Random.Shared.NextDouble() < 0.3;
+        }
+    }
+}

--- a/src/UltraWorldAI/Visualization/GenealogyVisualizer.cs
+++ b/src/UltraWorldAI/Visualization/GenealogyVisualizer.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using UltraWorldAI.Civilization;
+
+namespace UltraWorldAI.Visualization;
+
+/// <summary>
+/// Helper for printing genealogy trees.
+/// </summary>
+public static class GenealogyVisualizer
+{
+    public static string Render(GenealogyNode root)
+    {
+        var sb = new StringBuilder();
+        Traverse(root, 0, sb);
+        return sb.ToString();
+    }
+
+    private static void Traverse(GenealogyNode node, int indent, StringBuilder sb)
+    {
+        sb.AppendLine($"{new string(' ', indent * 2)}- {node.Name}");
+        foreach (var child in node.Descendants)
+        {
+            Traverse(child, indent + 1, sb);
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/CorruptionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CorruptionSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Politics;
+using Xunit;
+using System.Linq;
+
+public class CorruptionSystemTests
+{
+    [Fact]
+    public void InvestigationMarksCase()
+    {
+        CorruptionSystem.Cases.Clear();
+        CorruptionSystem.ReportCase("Prefeito", "Suborno");
+        CorruptionSystem.InvestigateAll();
+        Assert.True(CorruptionSystem.Cases.Any(c => c.Description == "Suborno" && c.Investigated));
+    }
+}

--- a/tests/UltraWorldAI.Tests/GenealogyVisualizerTests.cs
+++ b/tests/UltraWorldAI.Tests/GenealogyVisualizerTests.cs
@@ -1,0 +1,16 @@
+using UltraWorldAI.Civilization;
+using UltraWorldAI.Visualization;
+using Xunit;
+
+public class GenealogyVisualizerTests
+{
+    [Fact]
+    public void RenderReturnsTree()
+    {
+        var root = new GenealogyNode { Name = "Root" };
+        root.Descendants.Add(new GenealogyNode { Name = "Child" });
+        var output = GenealogyVisualizer.Render(root);
+        Assert.Contains("Root", output);
+        Assert.Contains("Child", output);
+    }
+}

--- a/tests/UltraWorldAI.Tests/MythGeneratorTests.cs
+++ b/tests/UltraWorldAI.Tests/MythGeneratorTests.cs
@@ -1,0 +1,12 @@
+using UltraWorldAI.Mythology;
+using Xunit;
+
+public class MythGeneratorTests
+{
+    [Fact]
+    public void GenerateLegendReturnsText()
+    {
+        var legend = MythGenerator.GenerateLegend();
+        Assert.Contains("Lenda", legend);
+    }
+}

--- a/tests/UltraWorldAI.Tests/PhotographicMemorySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PhotographicMemorySystemTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI;
+using Xunit;
+
+public class PhotographicMemorySystemTests
+{
+    [Fact]
+    public void DoesNotForgetMemories()
+    {
+        var mem = new PhotographicMemorySystem();
+        for (int i = 0; i < AISettings.MaxMemories * 2; i++)
+            mem.AddMemory($"m{i}");
+        Assert.Equal(AISettings.MaxMemories * 2, mem.Memories.Count);
+        var before = mem.Memories[0].Intensity;
+        mem.UpdateMemoryDecay();
+        Assert.Equal(before, mem.Memories[0].Intensity);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TaxPolicySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/TaxPolicySystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class TaxPolicySystemTests
+{
+    [Fact]
+    public void ApplyTaxCalculatesAmount()
+    {
+        TaxPolicySystem.SetTax("Villa", 0.2);
+        var due = TaxPolicySystem.ApplyTax("Villa", 100);
+        Assert.Equal(20, due, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- create `Mythology` module with procedural myth generator
- add photographic memory system and wire through `Person` and `Mind`
- expose genealogy visualization helper
- implement tax policy management and corruption cases
- tweak lifecycle rules and make memory system extensible
- add corresponding unit tests

## Testing
- `dotnet build tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842e6627424832389580c70829aefb2