### PR TITLE
Add culture origins and new world systems

### DIFF
--- a/src/UltraWorldAI/CultureSystem.cs
+++ b/src/UltraWorldAI/CultureSystem.cs
@@ -8,6 +8,7 @@ namespace UltraWorldAI
     public class Culture
     {
         public string Name { get; set; } = string.Empty;
+        public string OriginStory { get; set; } = string.Empty;
         public List<string> CoreValues { get; set; } = new();
         public List<string> Taboos { get; set; } = new();
         public List<Tradition> Traditions { get; set; } = new();
@@ -39,6 +40,7 @@ namespace UltraWorldAI
             var culture = new Culture
             {
                 Name = $"Cultura de {ideaTitle}",
+                OriginStory = GenerateOriginStory(ideaTitle),
                 CoreValues = keywords.Take(3).ToList(),
                 AestheticStyle = "mutável",
                 CalendarType = CalendarType.Lunar,
@@ -109,6 +111,21 @@ namespace UltraWorldAI
 
                 TraditionEngine.MutateTraditions(culture);
             }
+        }
+
+        private static string GenerateOriginStory(string seed)
+        {
+            var rand = new Random(seed.GetHashCode());
+            var myth = new[]
+            {
+                "formada a partir de um pacto ancestral",
+                "nascida de um êxodo espiritual",
+                "fundada após uma grande visão coletiva",
+                "originada em uma jornada através de terras místicas",
+                "erguida sobre ruínas esquecidas"
+            };
+
+            return $"Esta cultura foi {myth[rand.Next(myth.Length)]} inspirada pela ideia '{seed}'.";
         }
     }
 }

--- a/src/UltraWorldAI/Dialogue/AIDialogueSystem.cs
+++ b/src/UltraWorldAI/Dialogue/AIDialogueSystem.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace UltraWorldAI.Dialogue;
+
+public static class AIDialogueSystem
+{
+    private static readonly HttpClient Client = new();
+
+    public static async Task<string> GenerateDialogueAsync(string prompt)
+    {
+        var key = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        if (!string.IsNullOrWhiteSpace(key))
+        {
+            try
+            {
+                Client.DefaultRequestHeaders.Clear();
+                Client.DefaultRequestHeaders.Add("Authorization", $"Bearer {key}");
+                var content = new { model = "gpt-3.5-turbo", messages = new[] { new { role = "user", content = prompt } } };
+                var response = await Client.PostAsJsonAsync("https://api.openai.com/v1/chat/completions", content);
+                if (response.IsSuccessStatusCode)
+                {
+                    dynamic? data = await response.Content.ReadFromJsonAsync<dynamic>();
+                    return data?.choices[0]?.message?.content ?? string.Empty;
+                }
+            }
+            catch
+            {
+                // ignore connection issues
+            }
+        }
+
+        return $"AI: resposta para '{prompt}'";
+    }
+}

--- a/src/UltraWorldAI/Economy/CommodityMarketSystem.cs
+++ b/src/UltraWorldAI/Economy/CommodityMarketSystem.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Economy;
+
+public static class CommodityMarketSystem
+{
+    private static readonly Random Rand = new();
+    public static readonly Dictionary<string, double> Prices = new();
+
+    public static void RegisterCommodity(string name, double initialPrice)
+    {
+        Prices[name] = initialPrice;
+    }
+
+    public static void TickMarket()
+    {
+        foreach (var key in Prices.Keys.ToList())
+        {
+            var change = (Rand.NextDouble() - 0.5) * 0.1 * Prices[key];
+            Prices[key] = Math.Max(0.01, Prices[key] + change);
+        }
+    }
+
+    public static double GetPrice(string name)
+    {
+        return Prices.TryGetValue(name, out var p) ? p : 0.0;
+    }
+}

--- a/src/UltraWorldAI/LifeCycleSystem.cs
+++ b/src/UltraWorldAI/LifeCycleSystem.cs
@@ -15,7 +15,7 @@ public static class LifeCycleSystem
             < 60 => LifeStage.Adulto,
             _ => LifeStage.Idoso
         };
-        if (person.Age >= 80 && person.IsAlive)
+        if (person.Age > 80 && person.IsAlive)
             person.Die();
     }
 }

--- a/src/UltraWorldAI/StressSystem.cs
+++ b/src/UltraWorldAI/StressSystem.cs
@@ -45,5 +45,14 @@ namespace UltraWorldAI
             avg /= population.Count;
             return avg > 0.8f ? Politics.RevoltSystem.TriggerRevolt(gov, rebelLeader) : null;
         }
+
+        public static float GetAverageStress(System.Collections.Generic.List<Person> population)
+        {
+            if (population.Count == 0) return 0f;
+            float total = 0f;
+            foreach (var p in population)
+                total += p.Mind.Stress.CurrentStressLevel;
+            return total / population.Count;
+        }
     }
 }

--- a/src/UltraWorldAI/Territory/HabitationExpansionSystem.cs
+++ b/src/UltraWorldAI/Territory/HabitationExpansionSystem.cs
@@ -1,0 +1,24 @@
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Territory;
+
+public static class HabitationExpansionSystem
+{
+    /// <summary>
+    /// Adds housing units to a settlement increasing capacity.
+    /// </summary>
+    public static void BuildHousing(Settlement settlement, int units)
+    {
+        settlement.HousingUnits += units;
+        SettlementHistoryTracker.Register(settlement.Name, "Habitação", $"Construídas {units} casas");
+    }
+
+    /// <summary>
+    /// Claims a new region for the given settlement.
+    /// </summary>
+    public static void ExpandTerritory(Settlement settlement, string region)
+    {
+        TerritoryClaimSystem.ClaimRegion(region, settlement.Name, "Expansão territorial");
+        SettlementHistoryTracker.Register(settlement.Name, "Expansão", $"Expandiu para {region}");
+    }
+}

--- a/src/UltraWorldAI/World/CityArchitectureSystem.cs
+++ b/src/UltraWorldAI/World/CityArchitectureSystem.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public static class CityArchitectureSystem
+{
+    private static readonly Dictionary<string, string> Styles = new();
+
+    public static void SetStyle(Settlement settlement, string style)
+    {
+        settlement.ArchitectureStyle = style;
+        Styles[settlement.Name] = style;
+    }
+
+    public static string GetStyle(Settlement settlement)
+    {
+        return Styles.TryGetValue(settlement.Name, out var s) ? s : settlement.ArchitectureStyle;
+    }
+}

--- a/src/UltraWorldAI/World/RaceSettlementDistributor.cs
+++ b/src/UltraWorldAI/World/RaceSettlementDistributor.cs
@@ -12,6 +12,8 @@ public class Settlement
     public string Race { get; set; } = string.Empty;
     public string CultureSummary { get; set; } = string.Empty;
     public int Population { get; set; }
+    public int HousingUnits { get; set; }
+    public string ArchitectureStyle { get; set; } = "Comum";
 }
 
 public static class RaceSettlementDistributor
@@ -48,7 +50,9 @@ public static class RaceSettlementDistributor
                 Region = region.Name,
                 Race = race.Name,
                 CultureSummary = culture?.SocialStructure ?? "Desconhecida",
-                Population = rand.Next(200, 1000)
+                Population = rand.Next(200, 1000),
+                HousingUnits = rand.Next(50, 300),
+                ArchitectureStyle = rand.NextDouble() < 0.5 ? "Orgânica" : "Geométrica"
             });
 
             TerritoryClaimSystem.ClaimRegion(region.Name, race.Name, "Assentamento inicial");
@@ -59,6 +63,6 @@ public static class RaceSettlementDistributor
     {
         if (Settlements.Count == 0) return "Nenhum assentamento criado.";
         return string.Join("\n\n", Settlements.Select(s =>
-            $"\U0001F3D8️ {s.Name}\nRegião: {s.Region} | Raça: {s.Race}\nCultura: {s.CultureSummary}\nPopulação: {s.Population}"));
+            $"\U0001F3D8️ {s.Name}\nRegião: {s.Region} | Raça: {s.Race}\nCultura: {s.CultureSummary}\nPopulação: {s.Population} | Habitações: {s.HousingUnits} | Arquitetura: {s.ArchitectureStyle}"));
     }
 }

--- a/tests/UltraWorldAI.Tests/AIDialogueSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/AIDialogueSystemTests.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using UltraWorldAI.Dialogue;
+using Xunit;
+
+public class AIDialogueSystemTests
+{
+    [Fact]
+    public async Task GenerateDialogueReturnsText()
+    {
+        var text = await AIDialogueSystem.GenerateDialogueAsync("Ola");
+        Assert.False(string.IsNullOrWhiteSpace(text));
+    }
+}

--- a/tests/UltraWorldAI.Tests/CityArchitectureSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CityArchitectureSystemTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.World;
+using Xunit;
+
+public class CityArchitectureSystemTests
+{
+    [Fact]
+    public void SetStyleChangesSettlementProperty()
+    {
+        var settlement = new Settlement { Name = "Town" };
+        CityArchitectureSystem.SetStyle(settlement, "Barroco");
+        Assert.Equal("Barroco", settlement.ArchitectureStyle);
+        Assert.Equal("Barroco", CityArchitectureSystem.GetStyle(settlement));
+    }
+}

--- a/tests/UltraWorldAI.Tests/CommodityMarketSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CommodityMarketSystemTests.cs
@@ -1,0 +1,22 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class CommodityMarketSystemTests
+{
+    [Fact]
+    public void RegisterCommodityAddsPrice()
+    {
+        CommodityMarketSystem.RegisterCommodity("ouro", 10.0);
+        Assert.Equal(10.0, CommodityMarketSystem.GetPrice("ouro"));
+    }
+
+    [Fact]
+    public void TickMarketAltersPrice()
+    {
+        CommodityMarketSystem.RegisterCommodity("prata", 5.0);
+        var before = CommodityMarketSystem.GetPrice("prata");
+        CommodityMarketSystem.TickMarket();
+        var after = CommodityMarketSystem.GetPrice("prata");
+        Assert.NotEqual(before, after);
+    }
+}

--- a/tests/UltraWorldAI.Tests/CultureOriginStoryTests.cs
+++ b/tests/UltraWorldAI.Tests/CultureOriginStoryTests.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using Xunit;
+
+public class CultureOriginStoryTests
+{
+    [Fact]
+    public void CreateCultureIncludesOriginStory()
+    {
+        var system = new CultureSystem();
+        var culture = system.CreateCultureFromIdea("Inovacao", new List<string> { "Criatividade" });
+        Assert.False(string.IsNullOrWhiteSpace(culture.OriginStory));
+    }
+}

--- a/tests/UltraWorldAI.Tests/HabitationExpansionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/HabitationExpansionSystemTests.cs
@@ -1,0 +1,22 @@
+using UltraWorldAI.Territory;
+using UltraWorldAI.World;
+using Xunit;
+
+public class HabitationExpansionSystemTests
+{
+    [Fact]
+    public void BuildHousingIncreasesUnits()
+    {
+        var settlement = new Settlement { Name = "Camp", HousingUnits = 1 };
+        HabitationExpansionSystem.BuildHousing(settlement, 5);
+        Assert.Equal(6, settlement.HousingUnits);
+    }
+
+    [Fact]
+    public void ExpandTerritoryClaimsRegion()
+    {
+        var settlement = new Settlement { Name = "Camp" };
+        HabitationExpansionSystem.ExpandTerritory(settlement, "Nova Regiao");
+        Assert.Contains(TerritoryClaimSystem.Claims, c => c.RegionName == "Nova Regiao" && c.ClaimedBy == settlement.Name);
+    }
+}

--- a/tests/UltraWorldAI.Tests/PopulationStressEvaluatorTests.cs
+++ b/tests/UltraWorldAI.Tests/PopulationStressEvaluatorTests.cs
@@ -17,4 +17,14 @@ public class PopulationStressEvaluatorTests
         Assert.NotNull(result);
         Assert.Equal("Novo", gov.CurrentLeader);
     }
+
+    [Fact]
+    public void GetAverageStressReturnsMean()
+    {
+        var people = new List<Person> { new("A"), new("B") };
+        people[0].Mind.Stress.AddStress(0.5f);
+        people[1].Mind.Stress.AddStress(1.0f);
+        var avg = PopulationStressEvaluator.GetAverageStress(people);
+        Assert.InRange(avg, 0.74f, 0.76f);
+    }
 }


### PR DESCRIPTION
## Summary
- track culture origin stories
- support housing and territorial expansion
- integrate basic AI dialogue generator
- allow custom city architecture
- monitor average population stress
- create commodity market system
- update lifecycle death threshold
- test new features

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6842e6a47c3c83239d17d3cf36057e51