### PR TITLE
Add tutorial and extended visualization features

### DIFF
--- a/src/UltraWorldAI/Interface/TutorialSystem.cs
+++ b/src/UltraWorldAI/Interface/TutorialSystem.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Interface;
+
+/// <summary>
+/// Provides a simple narrated tutorial that advances through predefined steps.
+/// </summary>
+public class TutorialSystem
+{
+    private readonly Queue<string> _steps = new();
+
+    public TutorialSystem(IEnumerable<string> steps)
+    {
+        foreach (var step in steps)
+            _steps.Enqueue(step);
+    }
+
+    /// <summary>
+    /// Returns the next step text or null if finished.
+    /// </summary>
+    public string? NextStep()
+    {
+        return _steps.Count > 0 ? _steps.Dequeue() : null;
+    }
+
+    /// <summary>
+    /// Runs the tutorial interactively, waiting for user confirmation between steps.
+    /// </summary>
+    public void RunInteractive()
+    {
+        while (_steps.Count > 0)
+        {
+            Console.WriteLine(NextStep());
+            Console.ReadKey(true);
+        }
+    }
+}

--- a/src/UltraWorldAI/Politics/LeaderRankingSystem.cs
+++ b/src/UltraWorldAI/Politics/LeaderRankingSystem.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Politics;
+
+/// <summary>
+/// Maintains a ranking of historical leaders based on influence points.
+/// </summary>
+public static class LeaderRankingSystem
+{
+    private static readonly Dictionary<string, double> _leaders = new();
+
+    public static void Register(string leaderName, double influence)
+    {
+        if (_leaders.ContainsKey(leaderName))
+            _leaders[leaderName] += influence;
+        else
+            _leaders[leaderName] = influence;
+    }
+
+    public static IList<string> GetTop(int count)
+    {
+        return _leaders
+            .OrderByDescending(kvp => kvp.Value)
+            .Take(count)
+            .Select(kvp => kvp.Key)
+            .ToList();
+    }
+}

--- a/src/UltraWorldAI/Society/CollectiveIntelligenceSystem.cs
+++ b/src/UltraWorldAI/Society/CollectiveIntelligenceSystem.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Society;
+
+/// <summary>
+/// Demonstrates a simple swarm intelligence mechanism for collective decisions.
+/// </summary>
+public static class CollectiveIntelligenceSystem
+{
+    public static string Decide(IEnumerable<string> options, IEnumerable<string> votes)
+    {
+        var majority = votes
+            .GroupBy(v => v)
+            .OrderByDescending(g => g.Count())
+            .Select(g => g.Key)
+            .FirstOrDefault();
+        return majority ?? options.First();
+    }
+}

--- a/src/UltraWorldAI/Society/CommunityFeedbackSystem.cs
+++ b/src/UltraWorldAI/Society/CommunityFeedbackSystem.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Society;
+
+/// <summary>
+/// Collects community feedback and computes aggregate scores for balancing.
+/// </summary>
+public class CommunityFeedbackSystem
+{
+    private readonly Dictionary<string, List<int>> _feedback = new();
+
+    public void Submit(string feature, int score)
+    {
+        if (!_feedback.TryGetValue(feature, out var list))
+        {
+            list = new List<int>();
+            _feedback[feature] = list;
+        }
+        list.Add(score);
+    }
+
+    public double GetAverage(string feature)
+    {
+        return _feedback.TryGetValue(feature, out var list) && list.Count > 0
+            ? list.Average()
+            : 0.0;
+    }
+}

--- a/src/UltraWorldAI/Visualization/AugmentedRealityModule.cs
+++ b/src/UltraWorldAI/Visualization/AugmentedRealityModule.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace UltraWorldAI.Visualization;
+
+/// <summary>
+/// Placeholder augmented reality integration for visualizing world elements.
+/// </summary>
+public static class AugmentedRealityModule
+{
+    public static void RenderElement(string element)
+    {
+        Console.WriteLine($"[AR] Overlaying element: {element}");
+    }
+}

--- a/src/UltraWorldAI/Visualization/CulturalEvolutionGraph.cs
+++ b/src/UltraWorldAI/Visualization/CulturalEvolutionGraph.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Visualization;
+
+/// <summary>
+/// Simple container for cultural evolution data points to be visualized as a graph.
+/// </summary>
+public class CulturalEvolutionGraph
+{
+    private readonly List<(int year, double value)> _points = new();
+
+    public void AddPoint(int year, double value)
+    {
+        _points.Add((year, value));
+    }
+
+    public IReadOnlyList<(int year, double value)> GetPoints() => _points;
+}

--- a/src/UltraWorldAI/Visualization/ExternalAppExporter.cs
+++ b/src/UltraWorldAI/Visualization/ExternalAppExporter.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+
+namespace UltraWorldAI.Visualization;
+
+/// <summary>
+/// Exports summarized game data for consumption by external applications.
+/// </summary>
+public static class ExternalAppExporter
+{
+    public static string ExportSettlementData(World.Settlement settlement)
+    {
+        var info = new { settlement.Name, settlement.Region, settlement.Population };
+        return JsonSerializer.Serialize(info);
+    }
+}

--- a/tests/UltraWorldAI.Tests/CollectiveIntelligenceSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CollectiveIntelligenceSystemTests.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using UltraWorldAI.Society;
+using Xunit;
+
+public class CollectiveIntelligenceSystemTests
+{
+    [Fact]
+    public void DecideReturnsMajorityChoice()
+    {
+        var decision = CollectiveIntelligenceSystem.Decide(
+            new[] { "A", "B" },
+            new List<string> { "B", "B", "A" });
+        Assert.Equal("B", decision);
+    }
+}

--- a/tests/UltraWorldAI.Tests/CommunityFeedbackSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CommunityFeedbackSystemTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.Society;
+using Xunit;
+
+public class CommunityFeedbackSystemTests
+{
+    [Fact]
+    public void GetAverageReturnsMeanScore()
+    {
+        var system = new CommunityFeedbackSystem();
+        system.Submit("balance", 3);
+        system.Submit("balance", 5);
+        Assert.Equal(4.0, system.GetAverage("balance"), 1);
+    }
+}

--- a/tests/UltraWorldAI.Tests/CulturalEvolutionGraphTests.cs
+++ b/tests/UltraWorldAI.Tests/CulturalEvolutionGraphTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Visualization;
+using Xunit;
+
+public class CulturalEvolutionGraphTests
+{
+    [Fact]
+    public void AddPointStoresData()
+    {
+        var graph = new CulturalEvolutionGraph();
+        graph.AddPoint(100, 1.5);
+        Assert.Single(graph.GetPoints());
+    }
+}

--- a/tests/UltraWorldAI.Tests/ExternalAppExporterTests.cs
+++ b/tests/UltraWorldAI.Tests/ExternalAppExporterTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.Visualization;
+using UltraWorldAI.World;
+using Xunit;
+
+public class ExternalAppExporterTests
+{
+    [Fact]
+    public void ExportSettlementDataIncludesName()
+    {
+        var settlement = new Settlement { Name = "TestTown", Region = "R1", Population = 10 };
+        var json = ExternalAppExporter.ExportSettlementData(settlement);
+        Assert.Contains("TestTown", json);
+    }
+}

--- a/tests/UltraWorldAI.Tests/LeaderRankingSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LeaderRankingSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class LeaderRankingSystemTests
+{
+    [Fact]
+    public void GetTopOrdersByInfluence()
+    {
+        LeaderRankingSystem.Register("A", 1);
+        LeaderRankingSystem.Register("B", 3);
+        var list = LeaderRankingSystem.GetTop(2);
+        Assert.Equal("B", list[0]);
+        Assert.Equal("A", list[1]);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TutorialSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/TutorialSystemTests.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using UltraWorldAI.Interface;
+using Xunit;
+
+public class TutorialSystemTests
+{
+    [Fact]
+    public void NextStepReturnsInOrder()
+    {
+        var tutorial = new TutorialSystem(new[] { "step1", "step2" });
+        Assert.Equal("step1", tutorial.NextStep());
+        Assert.Equal("step2", tutorial.NextStep());
+        Assert.Null(tutorial.NextStep());
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple narrated `TutorialSystem`
- stub out `AugmentedRealityModule` for AR overlays
- allow exporting settlement data with `ExternalAppExporter`
- maintain leader ranking with `LeaderRankingSystem`
- store cultural evolution points with `CulturalEvolutionGraph`
- implement collective decision and community feedback systems
- provide unit tests for new features

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f416d6b48323bd838c35c0f16479