### PR TITLE
Improve docs and refactor mind update

### DIFF
--- a/AIConfig.json
+++ b/AIConfig.json
@@ -1,5 +1,7 @@
 {
   "MaxMemories": 150,
   "MemoryDecayRate": 0.01,
-  "StressDecayRate": 0.01
+  "StressDecayRate": 0.01,
+  "PersonalityMin": 0.3,
+  "PersonalityMax": 0.7
 }

--- a/README.md
+++ b/README.md
@@ -4,10 +4,33 @@ This repository contains the game code and the AI module. The AI logic is
 split across several files under `src/UltraWorldAI/`, each implementing
 interlinked systems that model memory, beliefs, personality, emotions and more.
 
+## Dependencies
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/) for building and running the project
+- [Microsoft.Data.Sqlite](https://www.nuget.org/packages/Microsoft.Data.Sqlite) for local storage
+- [xUnit](https://xunit.net/) for unit tests
+
+To generate coverage reports use:
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
 ## Structure
 - The `src/UltraWorldAI/` directory contains the implementation of all
   subsystems such as memory, beliefs, metacognition and the narrative engine.
 - `AIConfig.json` can override some runtime parameters (like `MaxMemories`).
+  Example:
+
+  ```json
+  {
+    "MaxMemories": 150,
+    "MemoryDecayRate": 0.01,
+    "StressDecayRate": 0.01,
+    "PersonalityMin": 0.3,
+    "PersonalityMax": 0.7
+  }
+  ```
 
 ### Features
 
@@ -109,3 +132,7 @@ Run the unit tests with:
 ```bash
 dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj
 ```
+
+## Diagrams
+
+An overview of the update cycle is provided as a Mermaid sequence diagram in [docs/sequence_diagram.md](docs/sequence_diagram.md).

--- a/docs/sequence_diagram.md
+++ b/docs/sequence_diagram.md
@@ -1,0 +1,12 @@
+```mermaid
+sequenceDiagram
+    participant G as GameLoop
+    participant P as Person
+    participant M as Mind
+    G->>P: Step()
+    P->>M: Update()
+    M->>M: UpdateDecaySystems()
+    M->>M: HandleIdeas()
+    M->>M: HandleDefenses()
+    M->>M: UpdateCultureSystems()
+```

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -117,6 +117,14 @@ namespace UltraWorldAI
 
         private void UpdateDecaySystems()
         {
+            DecayCoreSystems();
+            UpdateCognitiveCycles();
+            UpdateSymbolicBeliefs();
+            UpdateNarratives();
+        }
+
+        private void DecayCoreSystems()
+        {
             Memory.UpdateMemoryDecay();
             Emotions.UpdateEmotionsDecay();
             Knowledge.DecayFacts();
@@ -128,14 +136,26 @@ namespace UltraWorldAI
             ThoughtEngine.GenerateThought(this);
             ThoughtEngine.DecayThoughts();
             BrainMap.Decay();
+        }
+
+        private void UpdateCognitiveCycles()
+        {
             DynamicBeliefs.DecayBeliefs();
             Intuition.GenerateInsight(this);
             Symbols.DecaySymbols();
             Symbols.GenerateFromEmotion(Emotions);
             Symbols.IntegrateSymbolicMeaning(DynamicBeliefs);
             DynamicBeliefs.ResolveContradictions(Conflict, Emotions);
+        }
+
+        private void UpdateSymbolicBeliefs()
+        {
             PhilosophicalIntegrityScore = Integrity.EvaluateConsistency();
             Philosophy.Update(this);
+        }
+
+        private void UpdateNarratives()
+        {
             InternalNarrative.GenerateReflection(this);
             InternalNarrative.InteractWithSubvoices(Subvoices);
             Introspection.Reflect(this);
@@ -170,8 +190,8 @@ namespace UltraWorldAI
             Defenses.EvaluateDefenses(Conflict, Emotions, DynamicBeliefs);
             if (Defenses.IsEmotionBlocked("sorrow"))
             {
-                var s = Emotions.GetEmotion("sorrow") * 0.5f;
-                Emotions.SetEmotion("sorrow", s);
+                var reducedSorrow = Emotions.GetEmotion("sorrow") * 0.5f;
+                Emotions.SetEmotion("sorrow", reducedSorrow);
             }
             Defenses.Decay();
         }

--- a/src/UltraWorldAI/SymbolicMind.cs
+++ b/src/UltraWorldAI/SymbolicMind.cs
@@ -81,7 +81,7 @@ namespace UltraWorldAI
                     {
                         Archetype = parts[1].ToLowerInvariant(),
                         Meaning = parts[3].TrimEnd(';').ToLowerInvariant(),
-                        EmotionLinked = "",
+                        EmotionLinked = string.Empty,
                         Intensity = 0.5f,
                         CreatedAt = DateTime.Now
                     });

--- a/tests/UltraWorldAI.Tests/MemoryExtremeTests.cs
+++ b/tests/UltraWorldAI.Tests/MemoryExtremeTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI;
+using Xunit;
+
+public class MemoryExtremeTests
+{
+    [Fact]
+    public void AddMemoryRespectsMaxLimit()
+    {
+        var mem = new MemorySystem();
+        for (int i = 0; i < AISettings.MaxMemories + 20; i++)
+            mem.AddMemory($"e{i}");
+        Assert.Equal(AISettings.MaxMemories, mem.Memories.Count);
+    }
+}

--- a/tests/UltraWorldAI.Tests/TechIntentSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/TechIntentSystemTests.cs
@@ -8,7 +8,7 @@ public class TechIntentSystemTests
     public void InferPurposeRecognizesArt()
     {
         var concepts = new List<string> { "imagem", "som" };
-        var intent = TechIntentSystem.InferPurpose(concepts, "", "");
+        var intent = TechIntentSystem.InferPurpose(concepts, string.Empty, string.Empty);
         Assert.Equal("Expressar arte ou registrar", intent);
     }
 }


### PR DESCRIPTION
## Summary
- document dependencies and add config example
- add Mermaid sequence diagram
- standardise empty strings in SymbolicMind
- refactor Mind.Update into smaller private methods
- add memory limit test

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6842f69d261883238f434549ebc7494d