### PR TITLE
Add event sourcing and observer mode

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,7 +7,9 @@ public class Program
     {
         string configPath = args.Length > 0 ? args[0] : "AIConfig.json";
         IA.Initialize(configPath);
-        var loop = new GameLoop(5, 5, true);
+        var observer = args.Length > 1 && args[1] == "--observe";
+        AISettings.ObserverMode = observer;
+        var loop = new GameLoop(5, 5, true, observer);
         var alice = new Person("Alice");
         var bob = new Person("Bob");
         alice.Inventory.Add(new Item("Key"));

--- a/docs/compression_notes.md
+++ b/docs/compression_notes.md
@@ -1,0 +1,4 @@
+# Data Compression Considerations
+
+Large save files can be written using the `.gz` extension, which triggers compression in `MemorySystem.SaveMemories`.
+Monitor file sizes and enable compression when they exceed several megabytes.

--- a/docs/emotion_transitions.md
+++ b/docs/emotion_transitions.md
@@ -1,0 +1,5 @@
+# Emotional State Transitions
+
+This document describes how emotions decay and interact in the simulation.
+Each emotion value is updated on every tick by `EmotionSystem.UpdateEmotionsDecay`.
+The decay rates are defined in `AIConfig` and can be reloaded at runtime via `AISettings.Reload`.

--- a/docs/i18n_strategy.md
+++ b/docs/i18n_strategy.md
@@ -1,0 +1,5 @@
+# Internationalization Strategy
+
+All user facing strings should be looked up via `LocalizationManager`.
+Translations are stored as JSON files under `locales/<lang>.json`.
+The manager falls back to English when a key is missing.

--- a/src/UltraWorldAI/BaseTypes.cs
+++ b/src/UltraWorldAI/BaseTypes.cs
@@ -57,6 +57,8 @@ namespace UltraWorldAI
         public static float ForgottenMemoryThreshold = AIConfig.ForgottenMemoryThreshold;
         public static float PersonalityMin = AIConfig.DefaultPersonalityMin;
         public static float PersonalityMax = AIConfig.DefaultPersonalityMax;
+        public static bool ObserverMode = false;
+        public static EventSourcing.IEventStore? EventStore;
         public static void Load(string path)
         {
             if (!File.Exists(path)) return;
@@ -70,6 +72,8 @@ namespace UltraWorldAI
             if (data.TryGetValue("PersonalityMax", out var pmax)) PersonalityMax = pmax;
             if (data.TryGetValue("ForgottenMemoryThreshold", out var fmt)) ForgottenMemoryThreshold = fmt;
         }
+
+        public static void Reload(string path) => Load(path);
     }
 
     public enum LogLevel { Debug = 0, Info = 1, Warning = 2, Error = 3 }
@@ -78,6 +82,7 @@ namespace UltraWorldAI
     {
         public static LogLevel Level = LogLevel.Info;
         public static string? FilePath;
+        public static long MaxFileSizeBytes = 5 * 1024 * 1024;
         public static Dictionary<LogLevel, ConsoleColor> LevelColors { get; } = new()
         {
             [LogLevel.Debug] = ConsoleColor.Gray,
@@ -109,6 +114,9 @@ namespace UltraWorldAI
                 {
                     File.AppendAllText(FilePath!, formatted + Environment.NewLine);
                     if (ex != null) File.AppendAllText(FilePath!, ex.StackTrace + Environment.NewLine);
+                    var info = new FileInfo(FilePath!);
+                    if (info.Length > MaxFileSizeBytes)
+                        FilePath = Path.ChangeExtension(FilePath, $"{DateTime.Now:yyyyMMddHHmmss}.log");
                 }
                 catch (IOException)
                 {
@@ -135,6 +143,9 @@ namespace UltraWorldAI
                 {
                     await File.AppendAllTextAsync(FilePath!, formatted + Environment.NewLine);
                     if (ex != null) await File.AppendAllTextAsync(FilePath!, ex.StackTrace + Environment.NewLine);
+                    var info = new FileInfo(FilePath!);
+                    if (info.Length > MaxFileSizeBytes)
+                        FilePath = Path.ChangeExtension(FilePath, $"{DateTime.Now:yyyyMMddHHmmss}.log");
                 }
                 catch (IOException)
                 {

--- a/src/UltraWorldAI/EventSourcing/EventStore.cs
+++ b/src/UltraWorldAI/EventSourcing/EventStore.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+namespace UltraWorldAI.EventSourcing;
+
+public record EventRecord(string Type, string Data, DateTime Timestamp);
+
+public interface IEventStore
+{
+    void Record(EventRecord evt);
+    IReadOnlyList<EventRecord> GetEvents(string? type = null);
+}
+
+public class InMemoryEventStore : IEventStore
+{
+    private readonly List<EventRecord> _events = new();
+
+    public void Record(EventRecord evt)
+    {
+        _events.Add(evt);
+    }
+
+    public IReadOnlyList<EventRecord> GetEvents(string? type = null)
+    {
+        return type == null ? _events : _events.Where(e => e.Type == type).ToList();
+    }
+}

--- a/src/UltraWorldAI/Game/GameLoop.cs
+++ b/src/UltraWorldAI/Game/GameLoop.cs
@@ -1,3 +1,4 @@
+using UltraWorldAI;
 using System;
 using System.Collections.Generic;
 
@@ -7,8 +8,8 @@ public class GameLoop
 {
     private readonly GameMap _map;
     private readonly List<(Person person, int x, int y, int? tx, int? ty)> _actors = new();
-    private readonly Random _rng = new();
     private readonly bool _display;
+    private readonly bool _observerMode;
     private readonly IPathfinder _pathfinder;
     private GameDifficulty _difficulty = GameDifficulty.Normal;
 
@@ -28,10 +29,11 @@ public class GameLoop
         _ => 1
     };
 
-    public GameLoop(int width, int height, bool display = false, IPathfinder? pathfinder = null)
+    public GameLoop(int width, int height, bool display = false, bool observerMode = false, IPathfinder? pathfinder = null)
     {
         _map = new GameMap(width, height);
         _display = display;
+        _observerMode = observerMode;
         _pathfinder = pathfinder ?? new DefaultPathfinder();
     }
 
@@ -65,8 +67,8 @@ public class GameLoop
                 else
                 {
                     int range = StepRange;
-                    newX += _rng.Next(-range, range + 1);
-                    newY += _rng.Next(-range, range + 1);
+                    newX += RandomProvider.Next(-range, range + 1);
+                    newY += RandomProvider.Next(-range, range + 1);
                 }
 
                 newX = Math.Clamp(newX, 0, _map.Width - 1);
@@ -74,7 +76,8 @@ public class GameLoop
 
                 _map.Move(actor.person, actor.x, actor.y, newX, newY);
                 _actors[i] = (actor.person, newX, newY, actor.tx, actor.ty);
-                PersonUpdated?.Invoke(actor.person);
+                if (!_observerMode)
+                    PersonUpdated?.Invoke(actor.person);
             });
 
             if (_display)

--- a/src/UltraWorldAI/Localization/LocalizationManager.cs
+++ b/src/UltraWorldAI/Localization/LocalizationManager.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace UltraWorldAI.Localization;
+
+public static class LocalizationManager
+{
+    private static readonly Dictionary<string, Dictionary<string, string>> _cache = new();
+    public static string CurrentLanguage { get; set; } = "en";
+
+    public static void LoadLanguage(string lang, string path)
+    {
+        if (!File.Exists(path)) return;
+        var text = File.ReadAllText(path);
+        var data = JsonSerializer.Deserialize<Dictionary<string, string>>(text) ?? new();
+        _cache[lang] = data;
+    }
+
+    public static string Translate(string key)
+    {
+        if (_cache.TryGetValue(CurrentLanguage, out var lang) && lang.TryGetValue(key, out var value))
+            return value;
+        if (_cache.TryGetValue("en", out var en) && en.TryGetValue(key, out var fallback))
+            return fallback;
+        return key;
+    }
+}

--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -1,4 +1,5 @@
 using System;
+using UltraWorldAI.EventSourcing;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -51,6 +52,7 @@ namespace UltraWorldAI
                 Source = source,
                 Emotion = emotion
             });
+            AISettings.EventStore?.Record(new EventSourcing.EventRecord("MemoryAdded", summary, DateTime.Now));
             Memories = Memories.OrderByDescending(m => m.Date).ToList();
         }
 

--- a/src/UltraWorldAI/NarrativeEngine.cs
+++ b/src/UltraWorldAI/NarrativeEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using UltraWorldAI;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,7 +8,6 @@ namespace UltraWorldAI
     public class NarrativeEngine
     {
         private readonly Person _person;
-        private readonly Random _random = new Random();
 
         public NarrativeEngine(Person person)
         {
@@ -115,7 +115,7 @@ namespace UltraWorldAI
             projectionWeight /= totalWeight;
             repressionWeight /= totalWeight;
 
-            double roll = _random.NextDouble();
+            double roll = RandomProvider.NextDouble();
             string reflection;
 
             if (roll < justificationWeight)
@@ -186,7 +186,7 @@ namespace UltraWorldAI
                 justificationOptions.Add($"A raiva me impulsionou a agir contra a injustiça, servindo a um propósito positivo, apesar do desconforto.");
             }
 
-            string justification = justificationOptions.Any() ? justificationOptions[_random.Next(justificationOptions.Count)] :
+            string justification = justificationOptions.Any() ? justificationOptions[RandomProvider.Next(justificationOptions.Count)] :
                                         $"Houve uma boa razão para o que aconteceu. Não é o que parece à primeira vista.";
             return $"{baseContradiction} No entanto, {_person.Name} ponderou: \"{justification}\"";
         }
@@ -212,7 +212,7 @@ namespace UltraWorldAI
                 rationalizationOptions.Add($"A raiva que senti era meramente um catalisador energético, uma resposta fisiológica para aumentar meu foco.");
             }
 
-            string rationalization = rationalizationOptions.Any() ? rationalizationOptions[_random.Next(rationalizationOptions.Count)] :
+            string rationalization = rationalizationOptions.Any() ? rationalizationOptions[RandomProvider.Next(rationalizationOptions.Count)] :
                                         $"Se eu analisar bem, minha ação foi perfeitamente lógica e consistente com meus objetivos mais profundos.";
             return $"{baseContradiction} Mas {_person.Name} racionalizou: \"{rationalization}\"";
         }
@@ -239,7 +239,7 @@ namespace UltraWorldAI
 
         private string TryProject(string baseContradiction, string selfAspect, string conflictingAction)
         {
-            return $"{baseContradiction} {_person.Name} pensou: \"Na verdade, a culpa não foi minha. Foi a situação externa que me obrigou a agir, ou foi a falha de {(_random.NextDouble() > 0.5 ? "outra pessoa" : "o ambiente")} que me levou a isso.\"";
+            return $"{baseContradiction} {_person.Name} pensou: \"Na verdade, a culpa não foi minha. Foi a situação externa que me obrigou a agir, ou foi a falha de {(RandomProvider.NextDouble() > 0.5 ? "outra pessoa" : "o ambiente")} que me levou a isso.\"";
         }
 
         private string TryRepress(string baseContradiction, string selfAspect, string conflictingAction)

--- a/src/UltraWorldAI/RandomProvider.cs
+++ b/src/UltraWorldAI/RandomProvider.cs
@@ -1,0 +1,32 @@
+using System;
+namespace UltraWorldAI;
+
+public static class RandomProvider
+{
+    private static readonly Random _global = new();
+    private static readonly object _lock = new();
+
+    public static int Next(int min, int max)
+    {
+        lock (_lock)
+        {
+            return _global.Next(min, max);
+        }
+    }
+
+    public static int Next(int max)
+    {
+        lock (_lock)
+        {
+            return _global.Next(max);
+        }
+    }
+
+    public static double NextDouble()
+    {
+        lock (_lock)
+        {
+            return _global.NextDouble();
+        }
+    }
+}

--- a/src/UltraWorldAI/TechLoreSystem.cs
+++ b/src/UltraWorldAI/TechLoreSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using UltraWorldAI;
 
 namespace UltraWorldAI.Discovery;
 
@@ -32,7 +33,6 @@ public static class TechLoreSystem
         "foi esquecida e depois redescoberta"
     };
 
-    private static readonly Random Rng = new();
 
     public static string GenerateLore(ConceptualTech tech)
     {
@@ -42,5 +42,5 @@ public static class TechLoreSystem
                $"Reacao cultural: {RandomPick(Reactions)}";
     }
 
-    private static string RandomPick(string[] options) => options[Rng.Next(options.Length)];
+    private static string RandomPick(string[] options) => options[RandomProvider.Next(0, options.Length)];
 }

--- a/tools/new-test.sh
+++ b/tools/new-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Usage: tools/new-test.sh TestName
+name=$1
+if [ -z "$name" ]; then
+  echo "Usage: tools/new-test.sh TestName" >&2
+  exit 1
+fi
+cat > tests/UltraWorldAI.Tests/${name}.cs <<FILE
+using Xunit;
+using UltraWorldAI;
+
+public class ${name}
+{
+    [Fact]
+    public void Example()
+    {
+        Assert.True(true);
+    }
+}
+FILE


### PR DESCRIPTION
## Summary
- add observer mode support to GameLoop and Program
- create event sourcing infrastructure with EventRecord and InMemoryEventStore
- centralize RNG access via `RandomProvider`
- add LocalizationManager and docs on i18n and emotional transitions
- monitor log file size in Logger
- add script for generating new test files
- document data compression feature
- wire memory additions to event store

## Testing
- `dotnet build UltraWorldAI.csproj -c Release`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build -v m`

------
https://chatgpt.com/codex/tasks/task_e_68431b07493c832399b2faecc7d08afb