### PR TITLE
Add prophecy docs, config fallback and logging filter

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,6 +36,8 @@ jobs:
       run: dotnet build --no-restore
     - name: Test with coverage
       run: dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build --verbosity normal --collect:"XPlat Code Coverage"
+      env:
+        DOTNET_TEST_RUN_IN_PARALLEL: 'true'
     - name: Upload coverage
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ An overview of the update cycle is provided as a Mermaid sequence diagram in [do
 Additional usage examples can be found in [docs/advanced_examples.md](docs/advanced_examples.md).
 Video walkthroughs are listed in [docs/video_tutorials.md](docs/video_tutorials.md).
 Guidelines for scaling worlds to very large maps are documented in [docs/scaling_large_maps.md](docs/scaling_large_maps.md).
+Examples of fulfilled prophecies are listed in [docs/fulfilled_prophecies.md](docs/fulfilled_prophecies.md).
+The effect of doctrines on personality traits is described in [docs/doctrine_impact.md](docs/doctrine_impact.md).
+The module startup order is detailed in [docs/module_startup_order.md](docs/module_startup_order.md).
 
 ## Contributing
 

--- a/docs/doctrine_impact.md
+++ b/docs/doctrine_impact.md
@@ -1,0 +1,8 @@
+# Impacto das Doutrinas na Personalidade
+
+Quando um personagem absorve uma doutrina, certos traços de personalidade podem ser ajustados para refletir as regras aprendidas. Por exemplo:
+
+1. A doutrina "Caminho de Sol" ensina disciplina e registra nos traços aumento de autocontrole.
+2. Doutrinas baseadas em memória reforçam a lealdade, diminuindo impulsos de traição.
+
+Esses ajustes são aplicados pelo `DoctrineSystem` ao pregar para um alvo, modificando crenças e memórias relacionadas.

--- a/docs/fulfilled_prophecies.md
+++ b/docs/fulfilled_prophecies.md
@@ -1,0 +1,6 @@
+# Exemplos de Profecias Cumpridas
+
+O sistema de profecias registra previsões e verifica quando elas se concretizam. Abaixo estão dois exemplos simples:
+
+- **Queda do Sol** – originada por um oráculo em sonho, foi registrada com o gatilho `Eclipse total`. Quando o evento ocorreu, a profecia foi marcada como cumprida.
+- **Visão do Portal** – um mago anunciou que um portal seria aberto após a chave correta ser encontrada. Após a memória "Portal aberto" ser registrada, o sistema atualizou o status para cumprida.

--- a/docs/module_startup_order.md
+++ b/docs/module_startup_order.md
@@ -1,0 +1,8 @@
+# Ordem de Inicialização dos Módulos
+
+1. **IA.Initialize** – Carrega as configurações definidas em `AIConfig.json` ou aplica os valores padrão de `AIConfig`.
+2. **GameLoop** – Cria o mapa de jogo e define modos de exibição e observação.
+3. **Person** – Cada personagem é instanciado com sistemas internos como memória e crenças.
+4. **Sub-sistemas** – Durante a atualização, módulos como `MemorySystem`, `BeliefSystem` e `DoctrineSystem` são executados nessa ordem.
+
+A sequência garante que todas as dependências estejam prontas antes que o loop principal comece.

--- a/docs/test_output_example.md
+++ b/docs/test_output_example.md
@@ -1,0 +1,11 @@
+# Saída de Testes
+
+Exemplo de trecho gerado após executar `dotnet test`:
+
+```
+🗣️ Escola propagado em Cinzentos → Influência atual: 20.0
+🗣️ Escola propagado em Aurora → Influência atual: 30.0
+🗣️ Escola propagado em Aurora → Influência atual: 100.0
+
+Passed!  - Failed:     0, Passed:   231, Skipped:     0, Total:   231, Duration:  724 ms - UltraWorldAI.Tests.dll (net8.0)
+```

--- a/src/UltraWorldAI/BaseTypes.cs
+++ b/src/UltraWorldAI/BaseTypes.cs
@@ -59,8 +59,19 @@ namespace UltraWorldAI
         public static float PersonalityMax = AIConfig.DefaultPersonalityMax;
         public static bool ObserverMode = false;
         public static EventSourcing.IEventStore? EventStore;
+        public static void ApplyDefaults()
+        {
+            MaxMemories = AIConfig.MaxMemories;
+            MemoryDecayRate = AIConfig.MemoryDecayRate;
+            StressDecayRate = AIConfig.StressDecayRate;
+            ForgottenMemoryThreshold = AIConfig.ForgottenMemoryThreshold;
+            PersonalityMin = AIConfig.DefaultPersonalityMin;
+            PersonalityMax = AIConfig.DefaultPersonalityMax;
+        }
+
         public static void Load(string path)
         {
+            ApplyDefaults();
             if (!File.Exists(path)) return;
             var json = File.ReadAllText(path);
             var data = JsonSerializer.Deserialize<Dictionary<string, float>>(json);
@@ -96,9 +107,12 @@ namespace UltraWorldAI
             LevelColors[level] = color;
         }
 
+        public static Func<string, LogLevel, bool>? EventFilter;
+
         public static void Log(string message, LogLevel level = LogLevel.Info, Exception? ex = null)
         {
             if (level < Level) return;
+            if (EventFilter != null && !EventFilter.Invoke(message, level)) return;
             var formatted = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}][{level}] {message}";
             if (ex != null) formatted += $" Exception: {ex.Message}";
 
@@ -128,6 +142,7 @@ namespace UltraWorldAI
         public static async Task LogAsync(string message, LogLevel level = LogLevel.Info, Exception? ex = null)
         {
             if (level < Level) return;
+            if (EventFilter != null && !EventFilter.Invoke(message, level)) return;
             var formatted = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}][{level}] {message}";
             if (ex != null) formatted += $" Exception: {ex.Message}";
 

--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -16,11 +16,6 @@ namespace UltraWorldAI
     /// </summary>
     public partial class MemorySystem
     {
-        private static readonly JsonSerializerOptions _options = new()
-        {
-            WriteIndented = false,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
         /// <summary>
         /// List of all memories known by the agent, ordered from newest to oldest.
         /// </summary>
@@ -110,7 +105,7 @@ namespace UltraWorldAI
             };
             try
             {
-                var json = JsonSerializer.Serialize(state, _options);
+                var json = JsonSerializer.Serialize(state, MemorySystemJsonContext.Default.PersistedState);
                 File.WriteAllText(path, json);
             }
             catch (IOException ex)
@@ -143,7 +138,7 @@ namespace UltraWorldAI
                 {
                     await using var fs = File.Create(path);
                     await using var gz = new System.IO.Compression.GZipStream(fs, System.IO.Compression.CompressionLevel.Optimal);
-                    await JsonSerializer.SerializeAsync(gz, state, _options);
+                    await JsonSerializer.SerializeAsync(gz, state, MemorySystemJsonContext.Default.PersistedState);
                     return;
                 }
                 catch (IOException ex)
@@ -155,7 +150,7 @@ namespace UltraWorldAI
             try
             {
                 await using var fs = File.Create(path);
-                await JsonSerializer.SerializeAsync(fs, state, _options);
+                await JsonSerializer.SerializeAsync(fs, state, MemorySystemJsonContext.Default.PersistedState);
             }
             catch (IOException ex)
             {
@@ -185,7 +180,7 @@ namespace UltraWorldAI
             try
             {
                 var json = File.ReadAllText(path);
-                state = JsonSerializer.Deserialize<PersistedState>(json, _options);
+                state = JsonSerializer.Deserialize(json, MemorySystemJsonContext.Default.PersistedState);
             }
             catch (IOException ex)
             {
@@ -229,12 +224,12 @@ namespace UltraWorldAI
                 {
                     await using var fs = File.OpenRead(path);
                     await using var gz = new System.IO.Compression.GZipStream(fs, System.IO.Compression.CompressionMode.Decompress);
-                    state = await JsonSerializer.DeserializeAsync<PersistedState>(gz, _options);
+                    state = await JsonSerializer.DeserializeAsync(gz, MemorySystemJsonContext.Default.PersistedState);
                 }
                 else
                 {
                     var json = await File.ReadAllTextAsync(path);
-                    state = JsonSerializer.Deserialize<PersistedState>(json, _options);
+                    state = JsonSerializer.Deserialize(json, MemorySystemJsonContext.Default.PersistedState);
                 }
             }
             catch (IOException ex)
@@ -259,7 +254,7 @@ namespace UltraWorldAI
             }
         }
 
-        private class PersistedState
+        internal class PersistedState
         {
             public List<Memory> Memories { get; set; } = new();
             public Dictionary<string, float>? Beliefs { get; set; }

--- a/src/UltraWorldAI/MemorySystemJsonContext.cs
+++ b/src/UltraWorldAI/MemorySystemJsonContext.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace UltraWorldAI;
+
+[JsonSerializable(typeof(MemorySystem.PersistedState))]
+internal partial class MemorySystemJsonContext : JsonSerializerContext
+{
+}

--- a/src/UltraWorldAI/Religion/DoctrineEngine.cs
+++ b/src/UltraWorldAI/Religion/DoctrineEngine.cs
@@ -64,12 +64,12 @@ namespace UltraWorldAI.Religion
 
             if (god.Domain == DivineDomain.Memoria)
             {
-                list.Add("Escreva os nomes dos mortos com lagrimas.");
+                list.Add("Escreva os nomes dos mortos com lágrimas.");
             }
 
             if (god.Temperament == DivineTemperament.Vingativo)
             {
-                list.Add("Nao perdoe o traidor. Nem em pensamento.");
+                list.Add("Não perdoe o traidor. Nem em pensamento.");
             }
 
             return list;

--- a/tests/UltraWorldAI.Tests/GameLoopTests.cs
+++ b/tests/UltraWorldAI.Tests/GameLoopTests.cs
@@ -17,7 +17,7 @@ public class GameLoopTests
     [Fact]
     public void RunAdvancesActors()
     {
-        var loop = new GameLoop(3, 3, false, CreateMockPathfinder());
+        var loop = new GameLoop(3, 3, false, false, CreateMockPathfinder());
         var a = new Person("A");
         loop.AddPerson(a, 1, 1);
         var before = a.Mind.Memory.Memories.Count;
@@ -28,7 +28,7 @@ public class GameLoopTests
     [Fact]
     public void DifficultyChangesStepRange()
     {
-        var loop = new GameLoop(3, 3, false, CreateMockPathfinder());
+        var loop = new GameLoop(3, 3, false, false, CreateMockPathfinder());
         loop.Difficulty = GameDifficulty.Hard;
         Assert.Equal(GameDifficulty.Hard, loop.Difficulty);
         Assert.Equal(2, loop.StepRange);
@@ -37,7 +37,7 @@ public class GameLoopTests
     [Fact]
     public void PersonUpdatedEventIsRaised()
     {
-        var loop = new GameLoop(3, 3, false, CreateMockPathfinder());
+        var loop = new GameLoop(3, 3, false, false, CreateMockPathfinder());
         var p = new Person("Evt");
         loop.AddPerson(p, 0, 0);
         bool fired = false;

--- a/tests/UltraWorldAI.Tests/IntegrationSmokeTests.cs
+++ b/tests/UltraWorldAI.Tests/IntegrationSmokeTests.cs
@@ -9,7 +9,7 @@ namespace UltraWorldAI.Tests
     public class IntegrationSmokeTests
     {
         [Fact]
-        public void SandboxSystemsWorkTogether()
+        public void FaunaEvolutionAndGovernance()
         {
             FaunaEvolutionSystem.RegisterSpecies("Lobo", 5);
             FaunaEvolutionSystem.Evolve("Lobo");
@@ -20,12 +20,17 @@ namespace UltraWorldAI.Tests
             demo.ProposeLaw("Paz");
             demo.Vote("Paz", "Ana", true);
 
+            Assert.True(pop >= 0);
+            Assert.Contains("Paz", demo.GetApprovedLaws());
+        }
+
+        [Fact]
+        public void DoctrineCreationPersistsTexts()
+        {
             var doc = DoctrineEngine.CreateDoctrine(new DivineBeing { Name = "Sol", Domain = DivineDomain.Luz });
             DoctrineEngine.AddSacredText(doc, SacredTextType.Scroll);
             DoctrineEngine.AddSacredText(doc, SacredTextType.Hologram);
 
-            Assert.True(pop >= 0);
-            Assert.Contains("Paz", demo.GetApprovedLaws());
             Assert.Contains(SacredTextType.Scroll, doc.SacredTexts);
             Assert.Contains(SacredTextType.Hologram, doc.SacredTexts);
         }

--- a/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ProphecySystemTests.cs
@@ -1,6 +1,5 @@
 using UltraWorldAI;
 using UltraWorldAI.Religion;
-using UltraWorldAI;
 using Xunit;
 
 public class ProphecySystemTests


### PR DESCRIPTION
## Summary
- document module startup order, prophecy examples and doctrine impact
- save unit test output sample
- implement default config fallback and logging event filter
- add JSON source generation context for MemorySystem
- fix GameLoopTests, ProphecySystemTests
- split IntegrationSmokeTests into two
- update workflow to run tests in parallel
- minor orthography corrections

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68431e1c46d883239012d2175bd02eaa