### PR TITLE
Add doctrinal market and emotion systems

### DIFF
--- a/src/UltraWorldAI/Doctrine/DoctrinalEmotionResponseSystem.cs
+++ b/src/UltraWorldAI/Doctrine/DoctrinalEmotionResponseSystem.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Doctrine;
+
+public class DoctrinalEmotion
+{
+    public string IAName { get; set; } = string.Empty;
+    public string Doctrine { get; set; } = string.Empty;
+    public double FaithAttachment { get; set; }
+    public double Anger { get; set; }
+    public double Sadness { get; set; }
+    public double Fanaticism { get; set; }
+}
+
+public static class DoctrinalEmotionResponseSystem
+{
+    public static List<DoctrinalEmotion> Responses { get; } = new();
+
+    public static void RegisterIA(string name, string doctrine, double attachment)
+    {
+        Responses.Add(new DoctrinalEmotion
+        {
+            IAName = name,
+            Doctrine = doctrine,
+            FaithAttachment = attachment,
+            Anger = 0,
+            Sadness = 0,
+            Fanaticism = 0
+        });
+    }
+
+    public static void ReactToTrauma(string name, string betrayalType)
+    {
+        var r = Responses.Find(e => e.IAName == name);
+        if (r == null) return;
+
+        switch (betrayalType)
+        {
+            case "Profana\u00e7\u00e3o":
+                r.Anger += r.FaithAttachment * 0.5;
+                r.Fanaticism += r.FaithAttachment * 0.3;
+                break;
+            case "Heresia Interna":
+                r.Sadness += r.FaithAttachment * 0.4;
+                r.Fanaticism += r.FaithAttachment * 0.2;
+                break;
+            case "Censura da Doutrina":
+                r.Anger += r.FaithAttachment * 0.3;
+                r.Sadness += r.FaithAttachment * 0.3;
+                break;
+        }
+
+        Console.WriteLine($"\ud83d\udca5 {name} reagiu com emo\u00e7\u00f5es \u00e0 {betrayalType} da doutrina {r.Doctrine}:");
+        Console.WriteLine($"\ud83d\ude21 Raiva: {r.Anger:F2} | \ud83d\ude22 Tristeza: {r.Sadness:F2} | \ud83d\udd25 Fanatismo: {r.Fanaticism:F2}");
+    }
+}

--- a/src/UltraWorldAI/Doctrine/DoctrinalMarketSystem.cs
+++ b/src/UltraWorldAI/Doctrine/DoctrinalMarketSystem.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Doctrine;
+
+public class MarketPolicy
+{
+    public string Culture { get; set; } = string.Empty;
+    public string Doctrine { get; set; } = string.Empty;
+    public List<string> BannedProducts { get; set; } = new();
+    public List<string> SacredGoods { get; set; } = new();
+    public double TaxRate { get; set; }
+}
+
+public static class DoctrinalMarketSystem
+{
+    public static List<MarketPolicy> Policies { get; } = new();
+
+    public static void ApplyDoctrine(
+        string culture,
+        string doctrine,
+        List<string> banned,
+        List<string> sacred,
+        double tax)
+    {
+        Policies.Add(new MarketPolicy
+        {
+            Culture = culture,
+            Doctrine = doctrine,
+            BannedProducts = banned,
+            SacredGoods = sacred,
+            TaxRate = tax
+        });
+
+        Console.WriteLine($"\ud83d\udce6 {culture} aplicou a doutrina {doctrine}:");
+        Console.WriteLine($"\ud83d\udeab Proibidos: {string.Join(", ", banned)} | \u2728 Sagrados: {string.Join(", ", sacred)} | \ud83d\udcb0 Taxa: {tax * 100}%");
+    }
+
+    public static bool IsProductAllowed(string culture, string product)
+    {
+        var policy = Policies.FirstOrDefault(p => p.Culture == culture);
+        return policy == null || !policy.BannedProducts.Contains(product);
+    }
+
+    public static double GetTaxRate(string culture, string product)
+    {
+        var policy = Policies.FirstOrDefault(p => p.Culture == culture);
+        if (policy == null) return 0.1;
+        return policy.SacredGoods.Contains(product) ? 0.0 : policy.TaxRate;
+    }
+}

--- a/tests/UltraWorldAI.Tests/DoctrinalEmotionResponseSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrinalEmotionResponseSystemTests.cs
@@ -1,0 +1,24 @@
+using UltraWorldAI.Doctrine;
+using Xunit;
+
+public class DoctrinalEmotionResponseSystemTests
+{
+    [Fact]
+    public void RegisterIAStoresResponse()
+    {
+        DoctrinalEmotionResponseSystem.Responses.Clear();
+        DoctrinalEmotionResponseSystem.RegisterIA("Selena", "Caminho", 0.8);
+        Assert.Single(DoctrinalEmotionResponseSystem.Responses);
+    }
+
+    [Fact]
+    public void ReactToTraumaUpdatesEmotion()
+    {
+        DoctrinalEmotionResponseSystem.Responses.Clear();
+        DoctrinalEmotionResponseSystem.RegisterIA("Selena", "Caminho", 1.0);
+        DoctrinalEmotionResponseSystem.ReactToTrauma("Selena", "Profana\u00e7\u00e3o");
+        var r = DoctrinalEmotionResponseSystem.Responses[0];
+        Assert.True(r.Anger > 0);
+        Assert.True(r.Fanaticism > 0);
+    }
+}

--- a/tests/UltraWorldAI.Tests/DoctrinalMarketSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrinalMarketSystemTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using UltraWorldAI.Doctrine;
+using Xunit;
+
+public class DoctrinalMarketSystemTests
+{
+    [Fact]
+    public void ApplyDoctrineStoresPolicy()
+    {
+        DoctrinalMarketSystem.Policies.Clear();
+        DoctrinalMarketSystem.ApplyDoctrine(
+            "Aurora",
+            "Caminho do Valor Interno",
+            new List<string> { "Ouro" },
+            new List<string> { "Trigo" },
+            0.15);
+
+        Assert.Single(DoctrinalMarketSystem.Policies);
+        var policy = DoctrinalMarketSystem.Policies[0];
+        Assert.Equal("Aurora", policy.Culture);
+        Assert.Contains("Ouro", policy.BannedProducts);
+    }
+
+    [Fact]
+    public void SacredGoodsHaveNoTax()
+    {
+        DoctrinalMarketSystem.Policies.Clear();
+        DoctrinalMarketSystem.ApplyDoctrine(
+            "Aurora",
+            "Caminho",
+            new List<string>(),
+            new List<string> { "Trigo" },
+            0.2);
+
+        var rate = DoctrinalMarketSystem.GetTaxRate("Aurora", "Trigo");
+        Assert.Equal(0.0, rate);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DoctrinalMarketSystem` to let doctrines ban or bless goods
- implement `DoctrinalEmotionResponseSystem` for emotional reactions to doctrinal betrayal
- cover new systems with unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432cd1a058832383037011fb8af773