### PR TITLE
Add language heritage and conflict systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Sample culture data for quick experiments is available in
 - **ScientificDiscoveryGenerator** cria eventos aleatórios de descobertas científicas.
 - **CulturalEntertainmentSystem** mantém mídias de entretenimento por cultura.
 - **LanguageEvolutionSystem** faz evoluir dialetos ao longo do tempo.
+- **LanguageHeritageSystem** preserva idiomas como herança cultural e lamenta sua perda.
+- **ImperialLinguisticConflictSystem** registra disputas de idioma dentro de impérios.
+- **NeologismGenerator** permite que IAs criem novas palavras.
 - **AirTradeSystem** suporta rotas comerciais aéreas.
 - **ModScriptEngine** possibilita scripts externos de mods.
 - **ExternalAIConnector** integra serviços de IA de terceiros.

--- a/src/UltraWorldAI/Language/ImperialLinguisticConflictSystem.cs
+++ b/src/UltraWorldAI/Language/ImperialLinguisticConflictSystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class ImperialLanguageConflict
+{
+    public string RegionA { get; init; } = string.Empty;
+    public string RegionB { get; init; } = string.Empty;
+    public string Language { get; init; } = string.Empty;
+    public string Reason { get; init; } = string.Empty;
+}
+
+public static class ImperialLinguisticConflictSystem
+{
+    public static List<ImperialLanguageConflict> Conflicts { get; } = new();
+
+    public static void DeclareConflict(string regionA, string regionB, string language, string reason)
+    {
+        Conflicts.Add(new ImperialLanguageConflict
+        {
+            RegionA = regionA,
+            RegionB = regionB,
+            Language = language,
+            Reason = reason
+        });
+
+        Console.WriteLine($"\u2694\uFE0F Conflito lingu\u00edstico entre {regionA} e {regionB} sobre '{language}' \u2192 {reason}");
+    }
+
+    public static void PrintAllConflicts()
+    {
+        foreach (var c in Conflicts)
+            Console.WriteLine($"\n{c.RegionA} x {c.RegionB} ({c.Language}) - {c.Reason}");
+    }
+}

--- a/src/UltraWorldAI/Language/LanguageHeritageSystem.cs
+++ b/src/UltraWorldAI/Language/LanguageHeritageSystem.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LanguageHeritage
+{
+    public string Culture { get; set; } = string.Empty;
+    public List<string> Languages { get; set; } = new();
+}
+
+public static class LanguageHeritageSystem
+{
+    public static List<LanguageHeritage> Heritages { get; } = new();
+
+    public static void AddLanguage(string culture, string language)
+    {
+        var heritage = Heritages.Find(h => h.Culture == culture);
+        if (heritage == null)
+        {
+            heritage = new LanguageHeritage { Culture = culture };
+            Heritages.Add(heritage);
+        }
+        if (!heritage.Languages.Contains(language))
+            heritage.Languages.Add(language);
+    }
+
+    public static void RemoveLanguage(string culture, string language)
+    {
+        var heritage = Heritages.Find(h => h.Culture == culture);
+        if (heritage == null) return;
+        heritage.Languages.Remove(language);
+        if (heritage.Languages.Count == 0)
+            Console.WriteLine($"\uD83D\uDE2D {culture} lamenta a perda da l\u00edngua '{language}'.");
+    }
+
+    public static void PrintLanguages(string culture)
+    {
+        var heritage = Heritages.Find(h => h.Culture == culture);
+        if (heritage != null)
+            Console.WriteLine($"\n\uD83C\uDF0D {culture} preserva: {string.Join(", ", heritage.Languages)}");
+    }
+}

--- a/src/UltraWorldAI/Language/NeologismGenerator.cs
+++ b/src/UltraWorldAI/Language/NeologismGenerator.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Linq;
+
+namespace UltraWorldAI.Language;
+
+public static class NeologismGenerator
+{
+    private static readonly Random _rand = new();
+
+    public static string InventWord(Language lang, int length = 4)
+    {
+        if (lang.Phonemes.Count == 0 || length <= 0) return string.Empty;
+        var word = string.Concat(Enumerable.Range(0, length)
+            .Select(_ => lang.Phonemes[_rand.Next(lang.Phonemes.Count)]));
+        return word;
+    }
+}

--- a/tests/UltraWorldAI.Tests/ImperialLinguisticConflictSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ImperialLinguisticConflictSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class ImperialLinguisticConflictSystemTests
+{
+    [Fact]
+    public void DeclareConflictAddsEntry()
+    {
+        ImperialLinguisticConflictSystem.Conflicts.Clear();
+        ImperialLinguisticConflictSystem.DeclareConflict("R1", "R2", "Lang", "dominio");
+        Assert.Single(ImperialLinguisticConflictSystem.Conflicts);
+    }
+}

--- a/tests/UltraWorldAI.Tests/LanguageHeritageSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LanguageHeritageSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class LanguageHeritageSystemTests
+{
+    [Fact]
+    public void RemovingLastLanguageLeavesEmptyList()
+    {
+        LanguageHeritageSystem.Heritages.Clear();
+        LanguageHeritageSystem.AddLanguage("C", "L1");
+        LanguageHeritageSystem.RemoveLanguage("C", "L1");
+        var heritage = LanguageHeritageSystem.Heritages.Find(h => h.Culture == "C");
+        Assert.True(heritage == null || heritage.Languages.Count == 0);
+    }
+}

--- a/tests/UltraWorldAI.Tests/NeologismGeneratorTests.cs
+++ b/tests/UltraWorldAI.Tests/NeologismGeneratorTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class NeologismGeneratorTests
+{
+    [Fact]
+    public void InventWordRespectsLength()
+    {
+        LanguageCore.Languages.Clear();
+        var lang = LanguageCore.CreateLanguage("Neo", new() { "a", "b", "c" }, "SVO", "Alpha");
+        var word = NeologismGenerator.InventWord(lang, 3);
+        Assert.Equal(3, word.Length);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `LanguageHeritageSystem` for preserving languages by culture
- add `ImperialLinguisticConflictSystem` for multilingual strife
- create `NeologismGenerator` to invent new words
- update README with the new subsystems
- add unit tests for all new language features

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433546b2f88323b724b0af310361da