### PR TITLE
Add new linguistic systems

### DIFF
--- a/src/UltraWorldAI/Language/LanguageHeritageSystem.cs
+++ b/src/UltraWorldAI/Language/LanguageHeritageSystem.cs
@@ -6,38 +6,52 @@ namespace UltraWorldAI.Language;
 public class LanguageHeritage
 {
     public string Culture { get; set; } = string.Empty;
-    public List<string> Languages { get; set; } = new();
+    public string Language { get; set; } = string.Empty;
+    // 0-1 scale of emotional attachment
+    public double EmotionalAttachment { get; set; }
+    public bool IsSuppressed { get; set; }
+    public bool IsExtinct { get; set; }
 }
 
 public static class LanguageHeritageSystem
 {
     public static List<LanguageHeritage> Heritages { get; } = new();
 
-    public static void AddLanguage(string culture, string language)
+    public static void RegisterHeritage(string culture, string language, double attachment)
     {
-        var heritage = Heritages.Find(h => h.Culture == culture);
-        if (heritage == null)
+        Heritages.Add(new LanguageHeritage
         {
-            heritage = new LanguageHeritage { Culture = culture };
-            Heritages.Add(heritage);
-        }
-        if (!heritage.Languages.Contains(language))
-            heritage.Languages.Add(language);
+            Culture = culture,
+            Language = language,
+            EmotionalAttachment = attachment,
+            IsSuppressed = false,
+            IsExtinct = false
+        });
     }
 
-    public static void RemoveLanguage(string culture, string language)
+    public static void SuppressLanguage(string culture)
     {
         var heritage = Heritages.Find(h => h.Culture == culture);
         if (heritage == null) return;
-        heritage.Languages.Remove(language);
-        if (heritage.Languages.Count == 0)
-            Console.WriteLine($"\uD83D\uDE2D {culture} lamenta a perda da l\u00edngua '{language}'.");
+        heritage.IsSuppressed = true;
+        Console.WriteLine($"\u26A0\uFE0F A l\u00EDngua {heritage.Language} foi suprimida em {culture}.");
     }
 
-    public static void PrintLanguages(string culture)
+    public static void ExtinguishLanguage(string culture)
     {
         var heritage = Heritages.Find(h => h.Culture == culture);
-        if (heritage != null)
-            Console.WriteLine($"\n\uD83C\uDF0D {culture} preserva: {string.Join(", ", heritage.Languages)}");
+        if (heritage == null) return;
+        heritage.IsExtinct = true;
+        Console.WriteLine($"\uD83D\uDC80 A l\u00EDngua {heritage.Language} foi extinta. {culture} sofre trauma cultural.");
+    }
+
+    public static void ReactToLoss(string culture)
+    {
+        var heritage = Heritages.Find(h => h.Culture == culture);
+        if (heritage == null) return;
+
+        double rage = heritage.EmotionalAttachment * (heritage.IsSuppressed ? 0.5 : 0) + (heritage.IsExtinct ? 1 : 0);
+        if (rage > 0.7)
+            Console.WriteLine($"\uD83D\uDD25 {culture} inicia revolta lingu\u00EDstica pela perda da l\u00EDngua {heritage.Language}!");
     }
 }

--- a/src/UltraWorldAI/Language/LinguisticConflictSystem.cs
+++ b/src/UltraWorldAI/Language/LinguisticConflictSystem.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LinguisticRegion
+{
+    public string Empire { get; set; } = string.Empty;
+    public List<string> SpokenLanguages { get; set; } = new();
+    public string OfficialLanguage { get; set; } = string.Empty;
+    public Dictionary<string, double> Tensions { get; set; } = new();
+}
+
+public static class LinguisticConflictSystem
+{
+    public static List<LinguisticRegion> Regions { get; } = new();
+
+    public static void AddRegion(string empire, List<string> languages, string official)
+    {
+        var region = new LinguisticRegion
+        {
+            Empire = empire,
+            SpokenLanguages = languages,
+            OfficialLanguage = official
+        };
+
+        foreach (var lang in languages)
+            region.Tensions[lang] = lang == official ? 0 : 0.5;
+
+        Regions.Add(region);
+    }
+
+    public static void EnforceLanguage(string empire, string language)
+    {
+        var region = Regions.Find(r => r.Empire == empire);
+        if (region == null) return;
+
+        region.OfficialLanguage = language;
+
+        foreach (var lang in region.SpokenLanguages)
+        {
+            if (lang != language)
+                region.Tensions[lang] += 0.3;
+        }
+
+        Console.WriteLine($"\uD83D\uDCE3 {empire} imp\u00F4s {language} como l\u00EDngua oficial. Tens\u00F5es aumentam.");
+    }
+
+    public static void PrintTensions(string empire)
+    {
+        var region = Regions.Find(r => r.Empire == empire);
+        if (region == null) return;
+        Console.WriteLine($"\n\uD83D\uDDFA\uFE0F Tens\u00F5es lingu\u00EDsticas em {empire}:");
+        foreach (var kv in region.Tensions)
+            Console.WriteLine($"\uD83D\uDCAC {kv.Key} \u2192 tens\u00E3o: {kv.Value}");
+    }
+}

--- a/src/UltraWorldAI/Language/LinguisticCreativitySystem.cs
+++ b/src/UltraWorldAI/Language/LinguisticCreativitySystem.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LinguisticCreation
+{
+    public string IAName { get; set; } = string.Empty;
+    public string NativeLanguage { get; set; } = string.Empty;
+    public List<string> NewWords { get; set; } = new();
+    public List<string> BooksWritten { get; set; } = new();
+    public string? DialectName { get; set; }
+}
+
+public static class LinguisticCreativitySystem
+{
+    public static List<LinguisticCreation> Creations { get; } = new();
+
+    public static void RegisterCreator(string name, string language)
+    {
+        Creations.Add(new LinguisticCreation
+        {
+            IAName = name,
+            NativeLanguage = language
+        });
+    }
+
+    public static void InventWord(string name, string word)
+    {
+        var creator = Creations.Find(c => c.IAName == name);
+        if (creator == null) return;
+        creator.NewWords.Add(word);
+        Console.WriteLine($"\uD83D\uDC64 {name} inventou a palavra '{word}' na l\u00EDngua {creator.NativeLanguage}");
+    }
+
+    public static void WriteBook(string name, string title)
+    {
+        var creator = Creations.Find(c => c.IAName == name);
+        if (creator == null) return;
+        creator.BooksWritten.Add(title);
+        Console.WriteLine($"\uD83D\uDCD6 {name} escreveu o livro '{title}'");
+    }
+
+    public static void CreateDialect(string name, string dialect)
+    {
+        var creator = Creations.Find(c => c.IAName == name);
+        if (creator == null) return;
+        creator.DialectName = dialect;
+        Console.WriteLine($"\uD83C\uDF00 {name} fundou o dialeto '{dialect}' a partir de {creator.NativeLanguage}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/LanguageHeritageSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LanguageHeritageSystemTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 public class LanguageHeritageSystemTests
 {
     [Fact]
-    public void RemovingLastLanguageLeavesEmptyList()
+    public void SuppressLanguageMarksHeritage()
     {
         LanguageHeritageSystem.Heritages.Clear();
-        LanguageHeritageSystem.AddLanguage("C", "L1");
-        LanguageHeritageSystem.RemoveLanguage("C", "L1");
+        LanguageHeritageSystem.RegisterHeritage("C", "L1", 0.8);
+        LanguageHeritageSystem.SuppressLanguage("C");
         var heritage = LanguageHeritageSystem.Heritages.Find(h => h.Culture == "C");
-        Assert.True(heritage == null || heritage.Languages.Count == 0);
+        Assert.True(heritage?.IsSuppressed);
     }
 }

--- a/tests/UltraWorldAI.Tests/LinguisticConflictSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LinguisticConflictSystemTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using UltraWorldAI.Language;
+using Xunit;
+
+public class LinguisticConflictSystemTests
+{
+    [Fact]
+    public void EnforceLanguageIncreasesTension()
+    {
+        LinguisticConflictSystem.Regions.Clear();
+        LinguisticConflictSystem.AddRegion("Empire", new List<string> { "A", "B" }, "A");
+        LinguisticConflictSystem.EnforceLanguage("Empire", "A");
+        var region = LinguisticConflictSystem.Regions.Find(r => r.Empire == "Empire");
+        Assert.True(region!.Tensions["B"] > 0.5);
+    }
+}

--- a/tests/UltraWorldAI.Tests/LinguisticCreativitySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LinguisticCreativitySystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class LinguisticCreativitySystemTests
+{
+    [Fact]
+    public void InventWordAddsToList()
+    {
+        LinguisticCreativitySystem.Creations.Clear();
+        LinguisticCreativitySystem.RegisterCreator("AI", "Neo");
+        LinguisticCreativitySystem.InventWord("AI", "nova");
+        var creator = LinguisticCreativitySystem.Creations.Find(c => c.IAName == "AI");
+        Assert.Contains("nova", creator!.NewWords);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `LanguageHeritageSystem` with suppression and extinction reactions
- add new `LinguisticConflictSystem` and `LinguisticCreativitySystem`
- update tests for language heritage
- add tests for conflict and creativity systems

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684337ca0f608323a91b53667fc15b49