### PR TITLE
Add mystical language propagation and art systems

### DIFF
--- a/src/UltraWorldAI/Arts/LinguisticArtSchoolSystem.cs
+++ b/src/UltraWorldAI/Arts/LinguisticArtSchoolSystem.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Arts;
+
+public class ArtSchool
+{
+    public string Name { get; set; } = string.Empty;
+    public string Culture { get; set; } = string.Empty;
+    public string Style { get; set; } = string.Empty;
+    public List<string> KnownFor { get; set; } = new();
+    public List<string> Masters { get; set; } = new();
+}
+
+public static class LinguisticArtSchoolSystem
+{
+    public static List<ArtSchool> Schools { get; } = new();
+
+    public static void CreateSchool(string name, string culture, string style, List<string> knownFor)
+    {
+        Schools.Add(new ArtSchool
+        {
+            Name = name,
+            Culture = culture,
+            Style = style,
+            KnownFor = knownFor
+        });
+
+        Console.WriteLine($"\ud83c\udf93 Escola de arte criada: {name} | Cultura: {culture} | Estilo: {style}");
+    }
+
+    public static void AddMaster(string school, string masterName)
+    {
+        var s = Schools.Find(s => s.Name == school);
+        s?.Masters.Add(masterName);
+    }
+
+    public static void PrintSchools()
+    {
+        foreach (var s in Schools)
+        {
+            Console.WriteLine($"\n\ud83c\udfad {s.Name} | Cultura: {s.Culture} | Estilo: {s.Style}");
+            Console.WriteLine($"\ud83d\udcdc Conhecida por: {string.Join(", ", s.KnownFor)}");
+            Console.WriteLine($"\ud83d\udc51 Mestres: {string.Join(", ", s.Masters)}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Language/MysticLanguagePropagationSystem.cs
+++ b/src/UltraWorldAI/Language/MysticLanguagePropagationSystem.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.Religion;
+
+namespace UltraWorldAI.Language;
+
+public class LanguagePropagation
+{
+    public string Language { get; set; } = string.Empty;
+    public string Region { get; set; } = string.Empty;
+    public string Initiator { get; set; } = string.Empty;
+    public string Mode { get; set; } = string.Empty; // Culto, Tradicao, Resistencia
+}
+
+public static class MysticLanguagePropagationSystem
+{
+    public static List<LanguagePropagation> Propagations { get; } = new();
+
+    public static void Propagate(string language, string region, string initiator, string mode)
+    {
+        Propagations.Add(new LanguagePropagation
+        {
+            Language = language,
+            Region = region,
+            Initiator = initiator,
+            Mode = mode
+        });
+
+        Console.WriteLine($"\ud83c\udf10 L\u00edngua {language} propagada como {mode} em {region} por {initiator}");
+
+        switch (mode)
+        {
+            case "Culto":
+                HiddenCultSystem.SeedCult(language, region);
+                break;
+            case "Tradicao":
+                LanguageHeritageSystem.RegisterHeritage(region, language, 0.5);
+                break;
+            case "Resistencia":
+                LanguageHeritageSystem.RegisterHeritage(region, language, 0.9);
+                break;
+        }
+    }
+}

--- a/src/UltraWorldAI/Literature/PoeticSecretSystem.cs
+++ b/src/UltraWorldAI/Literature/PoeticSecretSystem.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Literature;
+
+public class PoeticSecret
+{
+    public string Creator { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string EncodedSecret { get; set; } = string.Empty;
+    public string UnlockForm { get; set; } = string.Empty; // "Lido em voz alta", "Em ritual", etc.
+}
+
+public static class PoeticSecretSystem
+{
+    public static List<PoeticSecret> Secrets { get; } = new();
+
+    public static void HideSecret(string creator, string title, string secret, string unlockForm)
+    {
+        Secrets.Add(new PoeticSecret
+        {
+            Creator = creator,
+            Title = title,
+            EncodedSecret = secret,
+            UnlockForm = unlockForm
+        });
+
+        Console.WriteLine($"\ud83d\udc9c Segredo escondido em poema: {title} (Criado por {creator})");
+    }
+
+    public static void AttemptUnlock(string title, string condition)
+    {
+        var s = Secrets.Find(s => s.Title == title);
+        if (s != null && s.UnlockForm == condition)
+            Console.WriteLine($"\ud83d\udd13 O poema '{title}' revelou o segredo: {s.EncodedSecret}");
+        else
+            Console.WriteLine($"\u274c O poema '{title}' n\u00e3o foi decifrado sob a condi\u00e7\u00e3o '{condition}'");
+    }
+
+    public static void PrintAllPoems()
+    {
+        foreach (var s in Secrets)
+        {
+            Console.WriteLine($"\n\ud83d\udcd6 {s.Title} | Forma de ativa\u00e7\u00e3o: {s.UnlockForm} | Criado por: {s.Creator}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Religion/DivineLinguisticConnectionSystem.cs
+++ b/src/UltraWorldAI/Religion/DivineLinguisticConnectionSystem.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public class DivineWord
+{
+    public string Language { get; set; } = string.Empty;
+    public string GodName { get; set; } = string.Empty;
+    public List<string> SacredWords { get; set; } = new();
+    public string ProphecyTrigger { get; set; } = string.Empty;
+}
+
+public static class DivineLinguisticConnectionSystem
+{
+    public static List<DivineWord> Registry { get; } = new();
+
+    public static void RegisterDivineWord(string language, string god, List<string> words, string prophecy)
+    {
+        Registry.Add(new DivineWord
+        {
+            Language = language,
+            GodName = god,
+            SacredWords = words,
+            ProphecyTrigger = prophecy
+        });
+
+        Console.WriteLine($"\ud83c\udf90 Deus {god} vinculado \u00e0 l\u00edngua {language}. Palavras sagradas: {string.Join(", ", words)}");
+    }
+
+    public static void Speak(string speaker, string language, string word)
+    {
+        var match = Registry.Find(d => d.Language == language && d.SacredWords.Contains(word));
+        if (match != null)
+            Console.WriteLine($"\ud83d\udd2e {speaker} pronunciou '{word}' em {language} \u2014 a aten\u00e7\u00e3o de {match.GodName} foi despertada: {match.ProphecyTrigger}");
+        else
+            Console.WriteLine($"{speaker} disse '{word}' sem impacto divino.");
+    }
+}

--- a/tests/UltraWorldAI.Tests/MysticLanguagePropagationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MysticLanguagePropagationSystemTests.cs
@@ -1,0 +1,21 @@
+using UltraWorldAI.Language;
+using UltraWorldAI.Religion;
+using UltraWorldAI.World;
+using Xunit;
+
+public class MysticLanguagePropagationSystemTests
+{
+    [Fact]
+    public void PropagateCultCreatesHiddenCult()
+    {
+        MysticLanguagePropagationSystem.Propagations.Clear();
+        HiddenCultSystem.ActiveCults.Clear();
+        SettlementHistoryTracker.Events.Clear();
+
+        MysticLanguagePropagationSystem.Propagate("Irith", "NeoCity", "IA", "Culto");
+
+        Assert.Contains(HiddenCultSystem.ActiveCults, c => c.BeliefSystem == "Irith");
+        Assert.Contains(MysticLanguagePropagationSystem.Propagations,
+            p => p.Language == "Irith" && p.Region == "NeoCity" && p.Mode == "Culto");
+    }
+}


### PR DESCRIPTION
## Summary
- enable connecting languages to deities via `DivineLinguisticConnectionSystem`
- add art schools for sacred performances
- store poetic secrets with unlock conditions
- propagate mystical languages as cults, traditions or acts of resistance
- test propagation creates hidden cults

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68433a58a12483239fe170abc04c1dac