### PR TITLE
Connect language cults to doctrines

### DIFF
--- a/src/UltraWorldAI/Language/LanguagePersonalitySystem.cs
+++ b/src/UltraWorldAI/Language/LanguagePersonalitySystem.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+
+namespace UltraWorldAI.Language;
+
+public static class LanguagePersonalitySystem
+{
+    private static readonly Dictionary<string, Dictionary<string, float>> TraitMap = new()
+    {
+        ["Irith"] = new() { ["Abertura"] = 0.05f },
+        ["Thal"] = new() { ["Conscienciosidade"] = 0.05f }
+    };
+
+    public static void ApplyTraits(Person person, string language)
+    {
+        if (!TraitMap.TryGetValue(language, out var adjustments))
+            return;
+        foreach (var pair in adjustments)
+            person.Mind.Personality.AdjustTrait(pair.Key, pair.Value);
+    }
+}

--- a/src/UltraWorldAI/Language/MysticLanguagePropagationSystem.cs
+++ b/src/UltraWorldAI/Language/MysticLanguagePropagationSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UltraWorldAI.Religion;
+using UltraWorldAI;
 
 namespace UltraWorldAI.Language;
 
@@ -15,6 +16,19 @@ public class LanguagePropagation
 public static class MysticLanguagePropagationSystem
 {
     public static List<LanguagePropagation> Propagations { get; } = new();
+    public static Dictionary<string, Doctrine> LanguageDoctrines { get; } = new();
+
+    private static Doctrine GetOrCreateDoctrine(string language)
+    {
+        if (LanguageDoctrines.TryGetValue(language, out var doctrine))
+            return doctrine;
+
+        var god = GodFactory.CreateGod($"Espirito de {language}", DivineDomain.Silencio, DivineTemperament.Dual);
+        doctrine = DoctrineEngine.CreateDoctrine(god);
+        DoctrineEngine.AddHeresy(doctrine, $"Culto linguistico de {language}");
+        LanguageDoctrines[language] = doctrine;
+        return doctrine;
+    }
 
     public static void Propagate(string language, string region, string initiator, string mode)
     {
@@ -32,6 +46,7 @@ public static class MysticLanguagePropagationSystem
         {
             case "Culto":
                 HiddenCultSystem.SeedCult(language, region);
+                GetOrCreateDoctrine(language);
                 break;
             case "Tradicao":
                 LanguageHeritageSystem.RegisterHeritage(region, language, 0.5);

--- a/tests/UltraWorldAI.Tests/LanguagePersonalitySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LanguagePersonalitySystemTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI.Language;
+using UltraWorldAI;
+using Xunit;
+
+public class LanguagePersonalitySystemTests
+{
+    [Fact]
+    public void ApplyTraitsModifiesPersonality()
+    {
+        var person = new Person("Falante");
+        var before = person.Mind.Personality.GetTrait("Abertura");
+
+        LanguagePersonalitySystem.ApplyTraits(person, "Irith");
+
+        Assert.True(person.Mind.Personality.GetTrait("Abertura") > before);
+    }
+}

--- a/tests/UltraWorldAI.Tests/MysticLanguagePropagationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MysticLanguagePropagationSystemTests.cs
@@ -1,6 +1,7 @@
 using UltraWorldAI.Language;
 using UltraWorldAI.Religion;
 using UltraWorldAI.World;
+using UltraWorldAI;
 using Xunit;
 
 public class MysticLanguagePropagationSystemTests
@@ -11,11 +12,15 @@ public class MysticLanguagePropagationSystemTests
         MysticLanguagePropagationSystem.Propagations.Clear();
         HiddenCultSystem.ActiveCults.Clear();
         SettlementHistoryTracker.Events.Clear();
+        DoctrineEngine.Doctrines.Clear();
 
         MysticLanguagePropagationSystem.Propagate("Irith", "NeoCity", "IA", "Culto");
 
         Assert.Contains(HiddenCultSystem.ActiveCults, c => c.BeliefSystem == "Irith");
         Assert.Contains(MysticLanguagePropagationSystem.Propagations,
             p => p.Language == "Irith" && p.Region == "NeoCity" && p.Mode == "Culto");
+        Assert.Contains(DoctrineEngine.Doctrines, d => d.Title.Contains("Irith"));
+        Assert.Contains(DoctrineEngine.Doctrines,
+            d => d.KnownHeresies.Contains("Culto linguistico de Irith"));
     }
 }


### PR DESCRIPTION
## Summary
- link MysticLanguagePropagationSystem to DoctrineEngine so every cult creates a doctrine and heresy
- implement LanguagePersonalitySystem to adjust personality traits based on spoken language
- add tests for cult-doctrine connection and language-personality mapping

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433dee8794832384f555344989018c