### PR TITLE
Add linguistic doctrine and personality systems

### DIFF
--- a/src/UltraWorldAI/Language/DoctrinalLinguisticAlignmentSystem.cs
+++ b/src/UltraWorldAI/Language/DoctrinalLinguisticAlignmentSystem.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LinguisticDoctrine
+{
+    public string CultName { get; set; } = string.Empty;
+    public string Language { get; set; } = string.Empty;
+    public string DoctrineName { get; set; } = string.Empty;
+    public bool IsHeretical { get; set; }
+    public string Stance { get; set; } = string.Empty; // "Reforma", "Resistência", "Dogma", "Cisma"
+}
+
+public static class DoctrinalLinguisticAlignmentSystem
+{
+    public static readonly List<LinguisticDoctrine> Doctrines = new();
+
+    public static void RegisterDoctrine(string cult, string language, string doctrine, bool heresy, string stance)
+    {
+        Doctrines.Add(new LinguisticDoctrine
+        {
+            CultName = cult,
+            Language = language,
+            DoctrineName = doctrine,
+            IsHeretical = heresy,
+            Stance = stance
+        });
+
+        Console.WriteLine($"\uD83D\uDCD6 Doutrina lingu\u00edstica registrada: {doctrine} (Culto: {cult}, L\u00edngua: {language}) \u2014 Heresia? {heresy} | Posi\u00e7\u00e3o: {stance}");
+    }
+
+    public static void PrintAll()
+    {
+        foreach (var d in Doctrines)
+        {
+            Console.WriteLine($"\n\u26EA {d.DoctrineName} | Culto: {d.CultName} | L\u00edngua: {d.Language}");
+            Console.WriteLine($"\uD83D\uDD25 Heresia? {d.IsHeretical} | Posi\u00e7\u00e3o: {d.Stance}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Language/LinguisticArchitectureInfluenceSystem.cs
+++ b/src/UltraWorldAI/Language/LinguisticArchitectureInfluenceSystem.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LinguisticArchitecture
+{
+    public string Civilization { get; set; } = string.Empty;
+    public string Language { get; set; } = string.Empty;
+    public string ArchitectureStyle { get; set; } = string.Empty;
+    public string WritingStyle { get; set; } = string.Empty;
+    public string Cosmology { get; set; } = string.Empty;
+}
+
+public static class LinguisticArchitectureInfluenceSystem
+{
+    public static readonly List<LinguisticArchitecture> Designs = new();
+
+    public static void DefineInfluence(string civ, string language, string architecture, string writing, string cosmology)
+    {
+        Designs.Add(new LinguisticArchitecture
+        {
+            Civilization = civ,
+            Language = language,
+            ArchitectureStyle = architecture,
+            WritingStyle = writing,
+            Cosmology = cosmology
+        });
+        Console.WriteLine($"\uD83C\uDFDB\uFE0F Civiliza\u00e7\u00e3o {civ} moldada pela l\u00edngua {language}.");
+    }
+
+    public static LinguisticArchitecture? GetInfluence(string civ) => Designs.Find(d => d.Civilization == civ);
+}

--- a/src/UltraWorldAI/Language/LinguisticPersonalityInfluenceSystem.cs
+++ b/src/UltraWorldAI/Language/LinguisticPersonalityInfluenceSystem.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class LinguisticStructure
+{
+    public string Language { get; set; } = string.Empty;
+    public string TimeView { get; set; } = string.Empty; // "C\u00edclico", "Linear", "Fragmentado"
+    public string EmotionStyle { get; set; } = string.Empty; // "Expl\u00edcito", "Contido", "Simbolizado"
+    public string ActionFocus { get; set; } = string.Empty; // "Verbo", "Estado", "Rela\u00e7\u00e3o"
+    public string CognitiveEffect { get; set; } = string.Empty; // "Empatia", "Agressividade", etc.
+}
+
+public class IALinguisticPersonality
+{
+    public string IAName { get; set; } = string.Empty;
+    public string Language { get; set; } = string.Empty;
+    public List<string> Traits { get; set; } = new();
+}
+
+public static class LinguisticPersonalityInfluenceSystem
+{
+    public static readonly List<LinguisticStructure> LanguageTraits = new();
+    public static readonly List<IALinguisticPersonality> Profiles = new();
+
+    public static void DefineStructure(string language, string time, string emotion, string action, string effect)
+    {
+        LanguageTraits.Add(new LinguisticStructure
+        {
+            Language = language,
+            TimeView = time,
+            EmotionStyle = emotion,
+            ActionFocus = action,
+            CognitiveEffect = effect
+        });
+
+        Console.WriteLine($"\uD83E\uDDE0 Estrutura definida para {language}: Tempo: {time}, Emo\u00e7\u00e3o: {emotion}, A\u00e7\u00e3o: {action} \u2192 Afeta: {effect}");
+    }
+
+    public static void AssignToIA(string ia, string language)
+    {
+        var traits = LanguageTraits.Find(l => l.Language == language);
+        if (traits == null) return;
+
+        Profiles.Add(new IALinguisticPersonality
+        {
+            IAName = ia,
+            Language = language,
+            Traits = new List<string>
+            {
+                $"Tempo: {traits.TimeView}",
+                $"Emo\u00e7\u00e3o: {traits.EmotionStyle}",
+                $"A\u00e7\u00e3o: {traits.ActionFocus}",
+                $"Tend\u00eancia: {traits.CognitiveEffect}"
+            }
+        });
+
+        Console.WriteLine($"\uD83E\uDDEC {ia} teve sua personalidade influenciada pela l\u00edngua {language}.");
+    }
+
+    public static void PrintProfile(string ia)
+    {
+        var p = Profiles.Find(p => p.IAName == ia);
+        if (p != null)
+        {
+            Console.WriteLine($"\n\uD83E\uDDE0 Perfil Lingu\u00edstico de {ia} | L\u00edngua: {p.Language}");
+            foreach (var t in p.Traits)
+                Console.WriteLine($"\uD83D\uDD39 {t}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Language/MultilingualMindSystem.cs
+++ b/src/UltraWorldAI/Language/MultilingualMindSystem.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public static class MultilingualMindSystem
+{
+    public static readonly Dictionary<string, List<string>> LanguagesByIA = new();
+
+    public static void TeachLanguage(string ia, string language)
+    {
+        if (!LanguagesByIA.TryGetValue(ia, out var list))
+        {
+            list = new List<string>();
+            LanguagesByIA[ia] = list;
+        }
+        if (!list.Contains(language))
+        {
+            list.Add(language);
+            LinguisticPersonalityInfluenceSystem.AssignToIA(ia, language);
+        }
+    }
+
+    public static string AnalyzeState(string ia)
+    {
+        if (!LanguagesByIA.TryGetValue(ia, out var langs) || langs.Count == 0)
+            return "Nenhum idioma";
+
+        var effects = new HashSet<string>();
+        foreach (var l in langs)
+        {
+            var traits = LinguisticPersonalityInfluenceSystem.LanguageTraits.Find(t => t.Language == l);
+            if (traits != null)
+                effects.Add(traits.CognitiveEffect);
+        }
+
+        return effects.Count > 1 ? "Conflito Interno" : langs.Count > 1 ? "Sabedoria M\u00faltipla" : "Est\u00e1vel";
+    }
+}

--- a/src/UltraWorldAI/Language/SacredLanguageEvolutionSystem.cs
+++ b/src/UltraWorldAI/Language/SacredLanguageEvolutionSystem.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class SacredLanguage
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> AcceptedForms { get; set; } = new();
+}
+
+public static class SacredLanguageEvolutionSystem
+{
+    public static readonly List<SacredLanguage> Languages = new();
+
+    public static void Register(string name, IEnumerable<string> forms)
+    {
+        Languages.Add(new SacredLanguage { Name = name, AcceptedForms = new List<string>(forms) });
+    }
+
+    public static bool Evolve(string name, string newForm)
+    {
+        var lang = Languages.Find(l => l.Name == name);
+        if (lang == null) return false;
+        var heresy = !lang.AcceptedForms.Contains(newForm);
+        if (heresy)
+            Console.WriteLine($"\u26A0\uFE0F Heresia lingu\u00edstica em {name}: {newForm}");
+        lang.AcceptedForms.Add(newForm);
+        return heresy;
+    }
+}

--- a/tests/UltraWorldAI.Tests/DoctrinalLinguisticAlignmentSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrinalLinguisticAlignmentSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class DoctrinalLinguisticAlignmentSystemTests
+{
+    [Fact]
+    public void RegisterDoctrineAddsEntry()
+    {
+        DoctrinalLinguisticAlignmentSystem.Doctrines.Clear();
+        DoctrinalLinguisticAlignmentSystem.RegisterDoctrine("Culto", "Irith", "V\u00e9u", false, "Dogma");
+        Assert.Single(DoctrinalLinguisticAlignmentSystem.Doctrines);
+    }
+}

--- a/tests/UltraWorldAI.Tests/LinguisticArchitectureInfluenceSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LinguisticArchitectureInfluenceSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class LinguisticArchitectureInfluenceSystemTests
+{
+    [Fact]
+    public void DefineInfluenceAddsDesign()
+    {
+        LinguisticArchitectureInfluenceSystem.Designs.Clear();
+        LinguisticArchitectureInfluenceSystem.DefineInfluence("Nova", "Irith", "Arcos", "Runas", "C\u00f3smos c\u00edclico");
+        Assert.Single(LinguisticArchitectureInfluenceSystem.Designs);
+    }
+}

--- a/tests/UltraWorldAI.Tests/LinguisticPersonalityInfluenceSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LinguisticPersonalityInfluenceSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class LinguisticPersonalityInfluenceSystemTests
+{
+    [Fact]
+    public void AssignCreatesProfile()
+    {
+        LinguisticPersonalityInfluenceSystem.LanguageTraits.Clear();
+        LinguisticPersonalityInfluenceSystem.Profiles.Clear();
+        LinguisticPersonalityInfluenceSystem.DefineStructure("Irith", "C\u00edclico", "Simbolizado", "Rela\u00e7\u00e3o", "Introspec\u00e7\u00e3o");
+        LinguisticPersonalityInfluenceSystem.AssignToIA("Kael", "Irith");
+        Assert.Single(LinguisticPersonalityInfluenceSystem.Profiles);
+    }
+}

--- a/tests/UltraWorldAI.Tests/MultilingualMindSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MultilingualMindSystemTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class MultilingualMindSystemTests
+{
+    [Fact]
+    public void AnalyzeStateDetectsConflict()
+    {
+        LinguisticPersonalityInfluenceSystem.LanguageTraits.Clear();
+        MultilingualMindSystem.LanguagesByIA.Clear();
+        LinguisticPersonalityInfluenceSystem.DefineStructure("Irith", "C\u00edclico", "Simbolizado", "Rela\u00e7\u00e3o", "Introspec\u00e7\u00e3o");
+        LinguisticPersonalityInfluenceSystem.DefineStructure("Thal", "Linear", "Expl\u00edcito", "Verbo", "Agressividade");
+        MultilingualMindSystem.TeachLanguage("Kael", "Irith");
+        MultilingualMindSystem.TeachLanguage("Kael", "Thal");
+        Assert.Equal("Conflito Interno", MultilingualMindSystem.AnalyzeState("Kael"));
+    }
+}

--- a/tests/UltraWorldAI.Tests/SacredLanguageEvolutionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/SacredLanguageEvolutionSystemTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class SacredLanguageEvolutionSystemTests
+{
+    [Fact]
+    public void EvolveReturnsHeresyWhenFormUnknown()
+    {
+        SacredLanguageEvolutionSystem.Languages.Clear();
+        SacredLanguageEvolutionSystem.Register("Irith", new[] { "forma1" });
+        var heresy = SacredLanguageEvolutionSystem.Evolve("Irith", "forma2");
+        Assert.True(heresy);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DoctrinalLinguisticAlignmentSystem` for tracking language-oriented doctrines
- add `LinguisticPersonalityInfluenceSystem` and `MultilingualMindSystem` to model language influence on AI
- support sacred language evolution and architectural influence systems
- add comprehensive unit tests for new features

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433fc43c44832396be8863b5be0580