### PR TITLE
Add script creation and magic words

### DIFF
--- a/src/UltraWorldAI/Language/AlphabetCreationSystem.cs
+++ b/src/UltraWorldAI/Language/AlphabetCreationSystem.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class InventedAlphabet
+{
+    public string Name { get; set; } = string.Empty;
+    public string Creator { get; set; } = string.Empty;
+    public string Style { get; set; } = string.Empty; // Calligraphy style
+    public string Value { get; set; } = string.Empty; // "Magico" ou "Social"
+}
+
+public static class AlphabetCreationSystem
+{
+    public static List<InventedAlphabet> Alphabets { get; } = new();
+
+    public static void Invent(string ia, string name, string style, string value)
+    {
+        Alphabets.Add(new InventedAlphabet
+        {
+            Creator = ia,
+            Name = name,
+            Style = style,
+            Value = value
+        });
+        Console.WriteLine($"\u270D\uFE0F {ia} criou o alfabeto '{name}' ({style}, valor {value})");
+    }
+}

--- a/src/UltraWorldAI/Language/MagicAccessWordSystem.cs
+++ b/src/UltraWorldAI/Language/MagicAccessWordSystem.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class MagicWord
+{
+    public string Word { get; set; } = string.Empty;
+    public string Purpose { get; set; } = string.Empty; // Artefato, Porta, Visao
+}
+
+public static class MagicAccessWordSystem
+{
+    public static List<MagicWord> Words { get; } = new();
+
+    public static void RegisterWord(string word, string purpose)
+    {
+        Words.Add(new MagicWord { Word = word, Purpose = purpose });
+        Console.WriteLine($"\uD83D\uDD12 Palavra magica '{word}' criada para {purpose}");
+    }
+
+    public static bool UseWord(string word, string purpose)
+    {
+        var w = Words.Find(x => x.Word == word && x.Purpose == purpose);
+        if (w != null)
+        {
+            Console.WriteLine($"\uD83D\uDD13 {word} desbloqueia {purpose}");
+            return true;
+        }
+        Console.WriteLine($"\u274C {word} falhou em {purpose}");
+        return false;
+    }
+}

--- a/src/UltraWorldAI/Language/MysticLanguagePropagationSystem.cs
+++ b/src/UltraWorldAI/Language/MysticLanguagePropagationSystem.cs
@@ -16,9 +16,9 @@ public class LanguagePropagation
 public static class MysticLanguagePropagationSystem
 {
     public static List<LanguagePropagation> Propagations { get; } = new();
-    public static Dictionary<string, Doctrine> LanguageDoctrines { get; } = new();
+    public static Dictionary<string, Religion.Doctrine> LanguageDoctrines { get; } = new();
 
-    private static Doctrine GetOrCreateDoctrine(string language)
+    private static Religion.Doctrine GetOrCreateDoctrine(string language)
     {
         if (LanguageDoctrines.TryGetValue(language, out var doctrine))
             return doctrine;

--- a/src/UltraWorldAI/Language/WritingExtinctionSystem.cs
+++ b/src/UltraWorldAI/Language/WritingExtinctionSystem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Language;
+
+public class WritingLegacy
+{
+    public string Name { get; set; } = string.Empty;
+    public int RememberedBy { get; set; }
+    public bool IsExtinct => RememberedBy <= 0;
+}
+
+public static class WritingExtinctionSystem
+{
+    public static List<WritingLegacy> Legacies { get; } = new();
+
+    public static void Remember(string name)
+    {
+        var record = Legacies.Find(l => l.Name == name);
+        if (record == null)
+        {
+            record = new WritingLegacy { Name = name };
+            Legacies.Add(record);
+        }
+        record.RememberedBy++;
+    }
+
+    public static void Forget(string name)
+    {
+        var record = Legacies.Find(l => l.Name == name);
+        if (record == null) return;
+        record.RememberedBy--;
+        if (record.IsExtinct)
+            Console.WriteLine($"\uD83D\uDC80 Legado da escrita {name} morreu.");
+    }
+
+    public static void Restore(string name, int people)
+    {
+        var record = Legacies.Find(l => l.Name == name);
+        if (record == null)
+        {
+            record = new WritingLegacy { Name = name };
+            Legacies.Add(record);
+        }
+        record.RememberedBy = people;
+        Console.WriteLine($"\u2728 Escrita {name} restaurada.");
+    }
+}

--- a/tests/UltraWorldAI.Tests/AlphabetCreationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/AlphabetCreationSystemTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class AlphabetCreationSystemTests
+{
+    [Fact]
+    public void InventAddsAlphabet()
+    {
+        AlphabetCreationSystem.Alphabets.Clear();
+        AlphabetCreationSystem.Invent("AI","Runica","Curvas","Magico");
+        Assert.Single(AlphabetCreationSystem.Alphabets);
+        Assert.Equal("Magico", AlphabetCreationSystem.Alphabets[0].Value);
+    }
+}

--- a/tests/UltraWorldAI.Tests/MagicAccessWordSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MagicAccessWordSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class MagicAccessWordSystemTests
+{
+    [Fact]
+    public void UseWordReturnsTrueWhenRegistered()
+    {
+        MagicAccessWordSystem.Words.Clear();
+        MagicAccessWordSystem.RegisterWord("abra","porta");
+        Assert.True(MagicAccessWordSystem.UseWord("abra","porta"));
+    }
+}

--- a/tests/UltraWorldAI.Tests/WritingExtinctionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/WritingExtinctionSystemTests.cs
@@ -1,0 +1,24 @@
+using UltraWorldAI.Language;
+using Xunit;
+
+public class WritingExtinctionSystemTests
+{
+    [Fact]
+    public void ForgetUntilZeroMarksExtinct()
+    {
+        WritingExtinctionSystem.Legacies.Clear();
+        WritingExtinctionSystem.Remember("Runica");
+        WritingExtinctionSystem.Forget("Runica");
+        Assert.True(WritingExtinctionSystem.Legacies[0].IsExtinct);
+    }
+
+    [Fact]
+    public void RestoreRevivesScript()
+    {
+        WritingExtinctionSystem.Legacies.Clear();
+        WritingExtinctionSystem.Remember("Runica");
+        WritingExtinctionSystem.Forget("Runica");
+        WritingExtinctionSystem.Restore("Runica", 1);
+        Assert.False(WritingExtinctionSystem.Legacies[0].IsExtinct);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AlphabetCreationSystem` to let IAs craft unique alphabets
- add `WritingExtinctionSystem` for script loss and restoration
- add `MagicAccessWordSystem` to handle magical access words
- adjust `MysticLanguagePropagationSystem` namespace usage
- test new language systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684341823a4883238a64c7be5aa90089