### PR TITLE
Add pre-stone age initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,14 @@ Before instantiating any `Person` objects, call `IA.Initialize()` so that runtim
 
 ### Example Game Loop
 
-The `GameLoop` class provides a very small wrapper to step through multiple `Person` objects on a simple tile map. Create a loop, add characters and run:
+The `GameLoop` class provides a very small wrapper to step through multiple `Person` objects on a simple tile map. Use `PrehistoricWorldInitializer` to begin with no knowledge in a pre-stone age era and then create a loop:
 
 ```csharp
 IA.Initialize();
+var deity = new Person("Deity");
+PrehistoricWorldInitializer.Initialize(deity);
 var loop = new GameLoop(5, 5, true);
-var alice = new Person("Alice");
-alice.Inventory.Add(new Item("Key"));
-loop.AddPerson(alice, 2, 2);
+loop.AddPerson(deity, 2, 2);
 loop.AddPerson(new Person("Bob"), 1, 1);
 loop.Run(3);
 ```

--- a/src/UltraWorldAI/MemorySystem.cs
+++ b/src/UltraWorldAI/MemorySystem.cs
@@ -94,6 +94,15 @@ namespace UltraWorldAI
         }
 
         /// <summary>
+        /// Removes all stored memories and clears internal caches.
+        /// </summary>
+        public void ClearAllMemories()
+        {
+            ClearCache();
+            Memories.Clear();
+        }
+
+        /// <summary>
         /// Persists memories and optional state to disk.
         /// </summary>
         /// <param name="path">Destination file path.</param>

--- a/src/UltraWorldAI/SemanticMemory.cs
+++ b/src/UltraWorldAI/SemanticMemory.cs
@@ -37,6 +37,14 @@ namespace UltraWorldAI
             foreach (var key in forgotten) Facts.Remove(key);
         }
 
+        /// <summary>
+        /// Clears all stored semantic facts.
+        /// </summary>
+        public void ClearFacts()
+        {
+            Facts.Clear();
+        }
+
         public string? Recall(string key)
         {
             return Facts.ContainsKey(key) ? Facts[key].Content : null;

--- a/src/UltraWorldAI/World/PrehistoricWorldInitializer.cs
+++ b/src/UltraWorldAI/World/PrehistoricWorldInitializer.cs
@@ -1,0 +1,21 @@
+using UltraWorldAI.History;
+
+namespace UltraWorldAI.World;
+
+/// <summary>
+/// Sets up a new simulation starting in a pre-stone age era with no knowledge.
+/// </summary>
+public static class PrehistoricWorldInitializer
+{
+    /// <summary>
+    /// Clears the given person's memories and knowledge and registers the
+    /// starting technological era.
+    /// </summary>
+    public static void Initialize(Person person)
+    {
+        person.Mind.Memory.ClearAllMemories();
+        person.Mind.Knowledge.ClearFacts();
+        TechTimelineSystem.Eras.Clear();
+        TechTimelineSystem.CreateEra("Pré-Pedra", "primitivo");
+    }
+}

--- a/tests/UltraWorldAI.Tests/PrehistoricWorldInitializerTests.cs
+++ b/tests/UltraWorldAI.Tests/PrehistoricWorldInitializerTests.cs
@@ -1,0 +1,22 @@
+using UltraWorldAI;
+using UltraWorldAI.World;
+using UltraWorldAI.History;
+using Xunit;
+
+public class PrehistoricWorldInitializerTests
+{
+    [Fact]
+    public void InitializeClearsKnowledgeAndRegistersEra()
+    {
+        var p = new Person("Tester");
+        p.Mind.Memory.AddMemory("old", 0.5f);
+        p.Mind.Knowledge.LearnFact("a", "b", 1f);
+
+        PrehistoricWorldInitializer.Initialize(p);
+
+        Assert.Empty(p.Mind.Memory.Memories);
+        Assert.Empty(p.Mind.Knowledge.Facts);
+        Assert.Single(TechTimelineSystem.Eras);
+        Assert.Contains("Pré-Pedra", TechTimelineSystem.Eras[0].Name);
+    }
+}


### PR DESCRIPTION
## Summary
- add method to clear memory
- add method to clear semantic facts
- implement `PrehistoricWorldInitializer` to wipe knowledge and set starting era
- document prehistoric setup in README
- test new initializer

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684346a4e6208323a7a3954327254c0b