### PR TITLE
Add dynasty, intrigue and government systems

### DIFF
--- a/src/UltraWorldAI/Politics/DynastySystem.cs
+++ b/src/UltraWorldAI/Politics/DynastySystem.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class RoyalMember
+{
+    public string Name { get; set; } = string.Empty;
+    public string House { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty; // "Rei", "Príncipe", "Bastardo", etc.
+    public string Parent1 { get; set; } = string.Empty;
+    public string Parent2 { get; set; } = string.Empty;
+    public bool IsLegitimate { get; set; }
+}
+
+public static class DynastySystem
+{
+    public static List<RoyalMember> Members { get; } = new();
+
+    public static void RegisterMember(string name, string house, string role, string p1, string p2, bool legit)
+    {
+        Members.Add(new RoyalMember
+        {
+            Name = name,
+            House = house,
+            Role = role,
+            Parent1 = p1,
+            Parent2 = p2,
+            IsLegitimate = legit
+        });
+
+        string status = legit ? "legítimo" : "bastardo";
+        Console.WriteLine($"🧬 {name} registrado na Casa {house} como {role} ({status})");
+    }
+
+    public static void PrintDynasty(string house)
+    {
+        Console.WriteLine($"\n🏰 Membros da Casa {house}:");
+        foreach (var m in Members)
+        {
+            if (m.House == house)
+                Console.WriteLine($"• {m.Role}: {m.Name} (Pais: {m.Parent1}, {m.Parent2}) | Legítimo? {m.IsLegitimate}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Politics/GovernmentFormSystem.cs
+++ b/src/UltraWorldAI/Politics/GovernmentFormSystem.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class GovernmentForm
+{
+    public string Kingdom { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty; // "Império", "República", "Teocracia", etc.
+    public string SourceOfPower { get; set; } = string.Empty; // "Força", "Voto", "Profecia", etc.
+    public string SuccessionLogic { get; set; } = string.Empty; // "Hereditária", "Eleições", etc.
+}
+
+public static class GovernmentFormSystem
+{
+    public static List<GovernmentForm> Forms { get; } = new();
+
+    public static void SetGovernment(string kingdom, string type, string powerSource, string succession)
+    {
+        Forms.Add(new GovernmentForm
+        {
+            Kingdom = kingdom,
+            Type = type,
+            SourceOfPower = powerSource,
+            SuccessionLogic = succession
+        });
+
+        Console.WriteLine($"⚖️ {kingdom} agora é uma {type} | Poder: {powerSource} | Sucessão: {succession}");
+    }
+
+    public static void PrintGovernments()
+    {
+        foreach (var f in Forms)
+        {
+            Console.WriteLine($"\n🏛️ {f.Kingdom}: {f.Type} | Origem do poder: {f.SourceOfPower} | Sucessão: {f.SuccessionLogic}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Politics/PowerIntrigueSystem.cs
+++ b/src/UltraWorldAI/Politics/PowerIntrigueSystem.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class PowerPlot
+{
+    public string Instigator { get; set; } = string.Empty;
+    public string TargetKingdom { get; set; } = string.Empty;
+    public string Method { get; set; } = string.Empty; // "Casamento", "Golpe", "Assassinato", "Suborno"
+    public bool WasSuccessful { get; set; }
+}
+
+public static class PowerIntrigueSystem
+{
+    public static List<PowerPlot> Plots { get; } = new();
+
+    public static void ExecutePlot(string instigator, string kingdom, string method)
+    {
+        var success = Random.Shared.NextDouble() > 0.4;
+        Plots.Add(new PowerPlot
+        {
+            Instigator = instigator,
+            TargetKingdom = kingdom,
+            Method = method,
+            WasSuccessful = success
+        });
+
+        Console.WriteLine(success
+            ? $"🎭 {instigator} executou com sucesso um {method} em {kingdom}."
+            : $"❌ {instigator} falhou ao tentar um {method} em {kingdom}.");
+    }
+
+    public static void PrintPlots()
+    {
+        foreach (var p in Plots)
+            Console.WriteLine($"\n🔪 {p.Instigator} tentou {p.Method} em {p.TargetKingdom} | Sucesso: {p.WasSuccessful}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/DynastySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DynastySystemTests.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class DynastySystemTests
+{
+    [Fact]
+    public void RegistersRoyalMember()
+    {
+        DynastySystem.Members.Clear();
+        DynastySystem.RegisterMember("Kael", "Umbra", "Rei", "Tharion", "Elria", true);
+        Assert.Contains(DynastySystem.Members, m => m.Name == "Kael" && m.IsLegitimate);
+    }
+}

--- a/tests/UltraWorldAI.Tests/GovernmentFormSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/GovernmentFormSystemTests.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class GovernmentFormSystemTests
+{
+    [Fact]
+    public void SetsGovernmentForm()
+    {
+        GovernmentFormSystem.Forms.Clear();
+        GovernmentFormSystem.SetGovernment("Reino de Kael", "Teocracia", "Profecia", "Escolhido");
+        Assert.Contains(GovernmentFormSystem.Forms, g => g.Kingdom == "Reino de Kael" && g.Type == "Teocracia");
+    }
+}

--- a/tests/UltraWorldAI.Tests/PowerIntrigueSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PowerIntrigueSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class PowerIntrigueSystemTests
+{
+    [Fact]
+    public void ExecutePlotAddsEntry()
+    {
+        PowerIntrigueSystem.Plots.Clear();
+        PowerIntrigueSystem.ExecutePlot("Selena", "Reino de Kael", "Golpe");
+        Assert.Single(PowerIntrigueSystem.Plots);
+    }
+}


### PR DESCRIPTION
## Summary
- add DynastySystem for bloodlines
- support PowerIntrigueSystem for coups and plots
- implement GovernmentFormSystem for emergent governments
- add basic unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: RealTimeStatsServerTests.ServerReturnsMapData, SuccessionConflictSystemTests.RevoltOrAssassinationWhenLegitimacyLow)*
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build --filter DynastySystemTests`


------
https://chatgpt.com/codex/tasks/task_e_68434a61023083239888f704530f9d99