### PR TITLE
Add dynasty myth and map modules

### DIFF
--- a/src/UltraWorldAI/Politics/DynasticMythosSystem.cs
+++ b/src/UltraWorldAI/Politics/DynasticMythosSystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class DynasticMyth
+{
+    public string HouseName { get; set; } = string.Empty;
+    public string OriginStory { get; set; } = string.Empty; // "Descendente dos Deuses", "Sangue Amaldiçoado", etc.
+    public bool IsRevered { get; set; }
+    public bool IsFeared { get; set; }
+}
+
+public static class DynasticMythosSystem
+{
+    public static List<DynasticMyth> Legends { get; } = new();
+
+    public static void DeclareMyth(string house, string story, bool revered, bool feared)
+    {
+        Legends.Add(new DynasticMyth
+        {
+            HouseName = house,
+            OriginStory = story,
+            IsRevered = revered,
+            IsFeared = feared
+        });
+
+        Console.WriteLine($"💠 Lenda criada: Casa {house} — {story} | Reverência: {revered} | Temor: {feared}");
+    }
+
+    public static void PrintMyths()
+    {
+        foreach (var d in Legends)
+            Console.WriteLine($"\n🏰 Casa {d.HouseName} | Lenda: {d.OriginStory} | Reverência: {d.IsRevered} | Temida? {d.IsFeared}");
+    }
+}

--- a/src/UltraWorldAI/Politics/NobleTitleSystem.cs
+++ b/src/UltraWorldAI/Politics/NobleTitleSystem.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class NobleTitle
+{
+    public string Name { get; set; } = string.Empty;
+    public string Holder { get; set; } = string.Empty;
+    public string Rank { get; set; } = string.Empty; // "Barão", "Conde", "Duque", "Rei", etc.
+    public string CrestSymbol { get; set; } = string.Empty;
+    public string House { get; set; } = string.Empty;
+}
+
+public static class NobleTitleSystem
+{
+    public static List<NobleTitle> Titles { get; } = new();
+
+    public static void GrantTitle(string name, string holder, string rank, string crest, string house)
+    {
+        Titles.Add(new NobleTitle
+        {
+            Name = name,
+            Holder = holder,
+            Rank = rank,
+            CrestSymbol = crest,
+            House = house
+        });
+
+        Console.WriteLine($"🛡️ {holder} recebeu o título de {rank} ({name}) com brasão '{crest}' da Casa {house}.");
+    }
+
+    public static void PrintTitles()
+    {
+        foreach (var t in Titles)
+            Console.WriteLine($"\n👑 {t.Rank} {t.Holder} | Título: {t.Name} | Casa: {t.House} | Heráldica: {t.CrestSymbol}");
+    }
+}

--- a/src/UltraWorldAI/Politics/SuccessionConflictSystem.cs
+++ b/src/UltraWorldAI/Politics/SuccessionConflictSystem.cs
@@ -8,6 +8,17 @@ public static class SuccessionConflictSystem
     public static string ResolveSuccession(PowerStructure gov, List<Person> candidates, string bloodline)
     {
         var successor = SuccessionSystem.DetermineSuccessor(gov, candidates, bloodline);
+
+        if (successor == gov.CurrentLeader && candidates.Count > 1)
+        {
+            var alt = candidates
+                .Where(c => c.Name != gov.CurrentLeader)
+                .OrderByDescending(c => LegitimacySystem.GetOverall(c.Name))
+                .FirstOrDefault();
+            if (alt != null)
+                successor = alt.Name;
+        }
+
         var legitimacy = LegitimacySystem.GetOverall(successor);
 
         if (legitimacy < 0.5f)

--- a/src/UltraWorldAI/Territory/PoliticalMapSystem.cs
+++ b/src/UltraWorldAI/Territory/PoliticalMapSystem.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Territory;
+
+public class Territory
+{
+    public string Name { get; set; } = string.Empty;
+    public string OwnerKingdom { get; set; } = string.Empty;
+    public string Governor { get; set; } = string.Empty;
+    public bool IsDisputed { get; set; }
+}
+
+public static class PoliticalMapSystem
+{
+    public static List<Territory> Regions { get; } = new();
+
+    public static void AssignRegion(string name, string owner, string governor, bool disputed)
+    {
+        Regions.Add(new Territory
+        {
+            Name = name,
+            OwnerKingdom = owner,
+            Governor = governor,
+            IsDisputed = disputed
+        });
+
+        Console.WriteLine(disputed
+            ? $"🗺️ Território em disputa: {name} (reivindicado por {owner}, governado por {governor})"
+            : $"🗺️ Território {name} governado por {governor} sob domínio de {owner}");
+    }
+
+    public static void PrintRegions()
+    {
+        foreach (var r in Regions)
+            Console.WriteLine($"\n🏞️ {r.Name} | Reino: {r.OwnerKingdom} | Governador: {r.Governor} | Disputa: {r.IsDisputed}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/DynasticMythosSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DynasticMythosSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class DynasticMythosSystemTests
+{
+    [Fact]
+    public void DeclareMythStoresLegend()
+    {
+        DynasticMythosSystem.Legends.Clear();
+        DynasticMythosSystem.DeclareMyth("Umbra", "Lua Negra", true, true);
+        Assert.Contains(DynasticMythosSystem.Legends, m => m.HouseName == "Umbra" && m.IsRevered);
+    }
+}

--- a/tests/UltraWorldAI.Tests/NobleTitleSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/NobleTitleSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class NobleTitleSystemTests
+{
+    [Fact]
+    public void GrantTitleAddsEntry()
+    {
+        NobleTitleSystem.Titles.Clear();
+        NobleTitleSystem.GrantTitle("Guardião", "Selena", "Duquesa", "Lobo", "Umbra");
+        Assert.Contains(NobleTitleSystem.Titles, t => t.Holder == "Selena" && t.Rank == "Duquesa");
+    }
+}

--- a/tests/UltraWorldAI.Tests/PoliticalMapSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PoliticalMapSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Territory;
+using Xunit;
+
+public class PoliticalMapSystemTests
+{
+    [Fact]
+    public void AssignRegionRegistersTerritory()
+    {
+        PoliticalMapSystem.Regions.Clear();
+        PoliticalMapSystem.AssignRegion("Vales", "Kael", "Selena", false);
+        Assert.Contains(PoliticalMapSystem.Regions, r => r.Name == "Vales" && !r.IsDisputed);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `NobleTitleSystem` for granting and listing noble titles
- implement `DynasticMythosSystem` for recording dynastic legends
- implement `PoliticalMapSystem` for tracking territorial control
- adjust `SuccessionConflictSystem` to pick alternative successor when current leader remains chosen
- add unit tests covering the new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68434e2fcc68832386a61fa42b8ab0e2