### PR TITLE
Add dynastic politics systems

### DIFF
--- a/src/UltraWorldAI/Politics/ChivalricOrderSystem.cs
+++ b/src/UltraWorldAI/Politics/ChivalricOrderSystem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class ChivalricOrder
+{
+    public string Name { get; set; } = string.Empty;
+    public string Founder { get; set; } = string.Empty;
+    public string Purpose { get; set; } = string.Empty; // "Proteger linhagem", "Caçar bruxas", "Manter paz"
+    public List<string> Members { get; } = new();
+}
+
+public static class ChivalricOrderSystem
+{
+    public static List<ChivalricOrder> Orders { get; } = new();
+
+    public static void CreateOrder(string name, string founder, string purpose)
+    {
+        Orders.Add(new ChivalricOrder
+        {
+            Name = name,
+            Founder = founder,
+            Purpose = purpose
+        });
+
+        Console.WriteLine($"🩸 Ordem fundada: {name} por {founder} | Missão: {purpose}");
+    }
+
+    public static void AddMember(string orderName, string member)
+    {
+        var o = Orders.Find(x => x.Name == orderName);
+        if (o != null)
+        {
+            o.Members.Add(member);
+            Console.WriteLine($"⚔️ {member} juntou-se à ordem {orderName}");
+        }
+    }
+
+    public static void PrintOrders()
+    {
+        foreach (var o in Orders)
+        {
+            Console.WriteLine($"\n🏅 {o.Name} | Fundador: {o.Founder} | Missão: {o.Purpose}");
+            Console.WriteLine($"• Membros: {string.Join(", ", o.Members)}");
+        }
+    }
+}

--- a/src/UltraWorldAI/Politics/CouncilRegencySystem.cs
+++ b/src/UltraWorldAI/Politics/CouncilRegencySystem.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class CouncilMember
+{
+    public string Name { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty; // "Chanceler", "Guardião", "Oráculo"
+    public bool IsLoyal { get; set; }
+}
+
+public class Regency
+{
+    public string Kingdom { get; set; } = string.Empty;
+    public string Regent { get; set; } = string.Empty;
+    public string Heir { get; set; } = string.Empty;
+    public bool IsHeirOfAge { get; set; }
+}
+
+public static class CouncilRegencySystem
+{
+    public static List<CouncilMember> Council { get; } = new();
+    public static List<Regency> Regencies { get; } = new();
+
+    public static void AddCouncilMember(string name, string role, bool loyal)
+    {
+        Council.Add(new CouncilMember
+        {
+            Name = name,
+            Role = role,
+            IsLoyal = loyal
+        });
+
+        Console.WriteLine($"🏛️ {name} entrou no Conselho como {role} | Leal? {loyal}");
+    }
+
+    public static void DeclareRegency(string kingdom, string regent, string heir, bool heirOfAge)
+    {
+        Regencies.Add(new Regency
+        {
+            Kingdom = kingdom,
+            Regent = regent,
+            Heir = heir,
+            IsHeirOfAge = heirOfAge
+        });
+
+        Console.WriteLine($"👶 {regent} assume regência de {kingdom} até {heir} atingir a maioridade.");
+    }
+
+    public static void PrintCouncil()
+    {
+        foreach (var c in Council)
+            Console.WriteLine($"\n👥 {c.Name} | Cargo: {c.Role} | Leal? {c.IsLoyal}");
+    }
+
+    public static void PrintRegencies()
+    {
+        foreach (var r in Regencies)
+            Console.WriteLine($"\n👑 Reino: {r.Kingdom} | Regente: {r.Regent} | Herdeiro: {r.Heir} | Maior de idade? {r.IsHeirOfAge}");
+    }
+}

--- a/src/UltraWorldAI/Politics/HiddenTitleSystem.cs
+++ b/src/UltraWorldAI/Politics/HiddenTitleSystem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class HiddenTitle
+{
+    public string Title { get; set; } = string.Empty;
+    public string Holder { get; set; } = string.Empty;
+    public string ConditionToReveal { get; set; } = string.Empty; // "Profecia", "Relíquia", "Conquista", etc.
+    public bool IsRevealed { get; set; }
+}
+
+public static class HiddenTitleSystem
+{
+    public static List<HiddenTitle> HiddenTitles { get; } = new();
+
+    public static void GrantHiddenTitle(string title, string holder, string condition)
+    {
+        HiddenTitles.Add(new HiddenTitle
+        {
+            Title = title,
+            Holder = holder,
+            ConditionToReveal = condition,
+            IsRevealed = false
+        });
+
+        Console.WriteLine($"🕯️ Título oculto '{title}' concedido a {holder}. Condição: {condition}");
+    }
+
+    public static void RevealTitle(string holder)
+    {
+        foreach (var t in HiddenTitles)
+        {
+            if (t.Holder == holder && !t.IsRevealed)
+            {
+                t.IsRevealed = true;
+                Console.WriteLine($"👑 Título oculto revelado: {t.Title} por {holder}!");
+            }
+        }
+    }
+
+    public static void PrintHiddenTitles()
+    {
+        foreach (var t in HiddenTitles)
+            Console.WriteLine($"\n🏷️ {t.Holder} | Título: {t.Title} | Revelado: {t.IsRevealed} | Condição: {t.ConditionToReveal}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/ChivalricOrderSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ChivalricOrderSystemTests.cs
@@ -1,0 +1,22 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class ChivalricOrderSystemTests
+{
+    [Fact]
+    public void CreateOrderAddsEntry()
+    {
+        ChivalricOrderSystem.Orders.Clear();
+        ChivalricOrderSystem.CreateOrder("Lanças da Aurora", "Kael", "Proteger");
+        Assert.Single(ChivalricOrderSystem.Orders);
+    }
+
+    [Fact]
+    public void AddMemberAppendsToOrder()
+    {
+        ChivalricOrderSystem.Orders.Clear();
+        ChivalricOrderSystem.CreateOrder("Lanças", "Kael", "Proteger");
+        ChivalricOrderSystem.AddMember("Lanças", "Tharon");
+        Assert.Contains("Tharon", ChivalricOrderSystem.Orders[0].Members);
+    }
+}

--- a/tests/UltraWorldAI.Tests/CouncilRegencySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CouncilRegencySystemTests.cs
@@ -1,0 +1,21 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class CouncilRegencySystemTests
+{
+    [Fact]
+    public void AddCouncilMemberAddsEntry()
+    {
+        CouncilRegencySystem.Council.Clear();
+        CouncilRegencySystem.AddCouncilMember("Selena", "Oráculo", true);
+        Assert.Single(CouncilRegencySystem.Council);
+    }
+
+    [Fact]
+    public void DeclareRegencyAddsEntry()
+    {
+        CouncilRegencySystem.Regencies.Clear();
+        CouncilRegencySystem.DeclareRegency("Umbra", "Selena", "Lyria", false);
+        Assert.Contains(CouncilRegencySystem.Regencies, r => r.Regent == "Selena" && r.Kingdom == "Umbra");
+    }
+}

--- a/tests/UltraWorldAI.Tests/HiddenTitleSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/HiddenTitleSystemTests.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class HiddenTitleSystemTests
+{
+    [Fact]
+    public void GrantHiddenTitleAddsEntry()
+    {
+        HiddenTitleSystem.HiddenTitles.Clear();
+        HiddenTitleSystem.GrantHiddenTitle("Rei Sob a Montanha", "Kael", "Profecia");
+        Assert.Contains(HiddenTitleSystem.HiddenTitles, t => t.Holder == "Kael" && t.Title == "Rei Sob a Montanha");
+    }
+
+    [Fact]
+    public void RevealTitleMarksRevealed()
+    {
+        HiddenTitleSystem.HiddenTitles.Clear();
+        HiddenTitleSystem.GrantHiddenTitle("Rei Sob a Montanha", "Kael", "Profecia");
+        HiddenTitleSystem.RevealTitle("Kael");
+        Assert.True(HiddenTitleSystem.HiddenTitles.First().IsRevealed);
+    }
+}


### PR DESCRIPTION
## Summary
- add `HiddenTitleSystem` for secret titles
- add `CouncilRegencySystem` for councils and regencies
- add `ChivalricOrderSystem` for chivalric orders
- test each new system

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684352bbc9008323bb44a70925e3a14e