### PR TITLE
Implement economic professions and corruption systems

### DIFF
--- a/src/UltraWorldAI/Economy/EconomicCorruptionSystem.cs
+++ b/src/UltraWorldAI/Economy/EconomicCorruptionSystem.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class MarketGuild
+{
+    public string Name { get; set; } = string.Empty;
+    public string Specialization { get; set; } = string.Empty;
+    public bool IsLegal { get; set; }
+}
+
+public class TaxPolicy
+{
+    public string Kingdom { get; set; } = string.Empty;
+    public string ResourceTaxed { get; set; } = string.Empty;
+    public double Rate { get; set; }
+}
+
+public class InflationIndex
+{
+    public string Currency { get; set; } = string.Empty;
+    public double InflationRate { get; set; }
+}
+
+public static class EconomicCorruptionSystem
+{
+    public static List<MarketGuild> Guilds { get; } = new();
+    public static List<TaxPolicy> Taxes { get; } = new();
+    public static List<InflationIndex> Inflation { get; } = new();
+
+    public static void CreateGuild(string name, string type, bool legal)
+    {
+        Guilds.Add(new MarketGuild { Name = name, Specialization = type, IsLegal = legal });
+        var status = legal ? "Guilda" : "Guilda ilegal";
+        Logger.Log($"[{status}] {name} - Setor: {type}");
+    }
+
+    public static void SetTax(string kingdom, string resource, double rate)
+    {
+        Taxes.Add(new TaxPolicy { Kingdom = kingdom, ResourceTaxed = resource, Rate = rate });
+        Logger.Log($"[Imposto] {kingdom} taxa {resource} em {rate * 100}%");
+    }
+
+    public static void UpdateInflation(string currency, double rate)
+    {
+        Inflation.Add(new InflationIndex { Currency = currency, InflationRate = rate });
+        Logger.Log($"[Inflacao] {currency} em {rate * 100}%");
+    }
+
+    public static IReadOnlyList<MarketGuild> ListGuilds() => Guilds;
+    public static IReadOnlyList<TaxPolicy> ListTaxes() => Taxes;
+    public static IReadOnlyList<InflationIndex> ListInflation() => Inflation;
+}

--- a/src/UltraWorldAI/Economy/ProfessionAndInnovationSystem.cs
+++ b/src/UltraWorldAI/Economy/ProfessionAndInnovationSystem.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Economy;
+
+public class Profession
+{
+    public string Name { get; set; } = string.Empty;
+    public string Tool { get; set; } = string.Empty;
+    public string Output { get; set; } = string.Empty;
+}
+
+public class Invention
+{
+    public string Name { get; set; } = string.Empty;
+    public string CreatedBy { get; set; } = string.Empty;
+    public string Effect { get; set; } = string.Empty;
+}
+
+public static class ProfessionAndInnovationSystem
+{
+    public static List<Profession> Professions { get; } = new();
+    public static List<Invention> Inventions { get; } = new();
+
+    public static void RegisterProfession(string name, string tool, string output)
+    {
+        Professions.Add(new Profession { Name = name, Tool = tool, Output = output });
+        Logger.Log($"[Profissao] {name} usa {tool} para criar {output}");
+    }
+
+    public static void RegisterInvention(string name, string creator, string effect)
+    {
+        Inventions.Add(new Invention { Name = name, CreatedBy = creator, Effect = effect });
+        Logger.Log($"[Inovacao] {name} por {creator} | Efeito: {effect}");
+    }
+
+    public static IReadOnlyList<Profession> ListProfessions() => Professions;
+    public static IReadOnlyList<Invention> ListInventions() => Inventions;
+}

--- a/tests/UltraWorldAI.Tests/EconomicCorruptionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/EconomicCorruptionSystemTests.cs
@@ -1,0 +1,40 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class EconomicCorruptionSystemTests
+{
+    [Fact]
+    public void CreateGuildAddsGuild()
+    {
+        EconomicCorruptionSystem.Guilds.Clear();
+        EconomicCorruptionSystem.CreateGuild("L\u00e2minas", "Rel\u00edquias", false);
+        Assert.Single(EconomicCorruptionSystem.Guilds);
+        var g = EconomicCorruptionSystem.Guilds[0];
+        Assert.Equal("L\u00e2minas", g.Name);
+        Assert.Equal("Rel\u00edquias", g.Specialization);
+        Assert.False(g.IsLegal);
+    }
+
+    [Fact]
+    public void SetTaxAddsPolicy()
+    {
+        EconomicCorruptionSystem.Taxes.Clear();
+        EconomicCorruptionSystem.SetTax("Umbra", "Ferro", 0.15);
+        Assert.Single(EconomicCorruptionSystem.Taxes);
+        var t = EconomicCorruptionSystem.Taxes[0];
+        Assert.Equal("Umbra", t.Kingdom);
+        Assert.Equal("Ferro", t.ResourceTaxed);
+        Assert.Equal(0.15, t.Rate, 3);
+    }
+
+    [Fact]
+    public void UpdateInflationAddsIndex()
+    {
+        EconomicCorruptionSystem.Inflation.Clear();
+        EconomicCorruptionSystem.UpdateInflation("Fragmento", 0.32);
+        Assert.Single(EconomicCorruptionSystem.Inflation);
+        var idx = EconomicCorruptionSystem.Inflation[0];
+        Assert.Equal("Fragmento", idx.Currency);
+        Assert.Equal(0.32, idx.InflationRate, 3);
+    }
+}

--- a/tests/UltraWorldAI.Tests/ProfessionAndInnovationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ProfessionAndInnovationSystemTests.cs
@@ -1,0 +1,29 @@
+using UltraWorldAI.Economy;
+using Xunit;
+
+public class ProfessionAndInnovationSystemTests
+{
+    [Fact]
+    public void RegisterProfessionAddsEntry()
+    {
+        ProfessionAndInnovationSystem.Professions.Clear();
+        ProfessionAndInnovationSystem.RegisterProfession("Tecel\u00e3o", "Tear", "Tecido");
+        Assert.Single(ProfessionAndInnovationSystem.Professions);
+        var p = ProfessionAndInnovationSystem.Professions[0];
+        Assert.Equal("Tecel\u00e3o", p.Name);
+        Assert.Equal("Tear", p.Tool);
+        Assert.Equal("Tecido", p.Output);
+    }
+
+    [Fact]
+    public void RegisterInventionAddsEntry()
+    {
+        ProfessionAndInnovationSystem.Inventions.Clear();
+        ProfessionAndInnovationSystem.RegisterInvention("Moeda Magica", "Aeron", "Dissolve");
+        Assert.Single(ProfessionAndInnovationSystem.Inventions);
+        var i = ProfessionAndInnovationSystem.Inventions[0];
+        Assert.Equal("Moeda Magica", i.Name);
+        Assert.Equal("Aeron", i.CreatedBy);
+        Assert.Equal("Dissolve", i.Effect);
+    }
+}


### PR DESCRIPTION
## Summary
- add ProfessionAndInnovationSystem for managing professions and inventions
- add EconomicCorruptionSystem for guilds, taxes and inflation
- test the new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435684db2883238bad52b58300d5f8