### PR TITLE
Add time and history modules

### DIFF
--- a/src/UltraWorldAI/Economy/EconomicCorruptionSystem.cs
+++ b/src/UltraWorldAI/Economy/EconomicCorruptionSystem.cs
@@ -9,7 +9,7 @@ public class MarketGuild
     public bool IsLegal { get; set; }
 }
 
-public class TaxPolicy
+public class KingdomTaxPolicy
 {
     public string Kingdom { get; set; } = string.Empty;
     public string ResourceTaxed { get; set; } = string.Empty;
@@ -25,7 +25,7 @@ public class InflationIndex
 public static class EconomicCorruptionSystem
 {
     public static List<MarketGuild> Guilds { get; } = new();
-    public static List<TaxPolicy> Taxes { get; } = new();
+    public static List<KingdomTaxPolicy> Taxes { get; } = new();
     public static List<InflationIndex> Inflation { get; } = new();
 
     public static void CreateGuild(string name, string type, bool legal)
@@ -37,7 +37,7 @@ public static class EconomicCorruptionSystem
 
     public static void SetTax(string kingdom, string resource, double rate)
     {
-        Taxes.Add(new TaxPolicy { Kingdom = kingdom, ResourceTaxed = resource, Rate = rate });
+        Taxes.Add(new KingdomTaxPolicy { Kingdom = kingdom, ResourceTaxed = resource, Rate = rate });
         Logger.Log($"[Imposto] {kingdom} taxa {resource} em {rate * 100}%");
     }
 
@@ -48,6 +48,6 @@ public static class EconomicCorruptionSystem
     }
 
     public static IReadOnlyList<MarketGuild> ListGuilds() => Guilds;
-    public static IReadOnlyList<TaxPolicy> ListTaxes() => Taxes;
+    public static IReadOnlyList<KingdomTaxPolicy> ListTaxes() => Taxes;
     public static IReadOnlyList<InflationIndex> ListInflation() => Inflation;
 }

--- a/src/UltraWorldAI/Time/EraTimelineSystem.cs
+++ b/src/UltraWorldAI/Time/EraTimelineSystem.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Time;
+
+public class Era
+{
+    public string Name { get; set; } = string.Empty;
+    public string Culture { get; set; } = string.Empty;
+    public int StartYear { get; set; }
+    public string Trigger { get; set; } = string.Empty;
+}
+
+public static class EraTimelineSystem
+{
+    public static List<Era> Eras { get; } = new();
+    public static int GlobalYear { get; private set; }
+
+    public static void AdvanceYear()
+    {
+        GlobalYear++;
+        Console.WriteLine($"\ud83d\udcc6 Ano atual: {GlobalYear}");
+    }
+
+    public static void StartEra(string culture, string name, string trigger)
+    {
+        Eras.Add(new Era
+        {
+            Name = name,
+            Culture = culture,
+            StartYear = GlobalYear,
+            Trigger = trigger
+        });
+
+        Console.WriteLine($"\ud83d\udd70\ufe0f Nova Era: {name} começou para {culture} | Gatilho: {trigger} | Ano: {GlobalYear}");
+    }
+
+    public static void PrintEras()
+    {
+        foreach (var e in Eras)
+            Console.WriteLine($"\n\ud83d\udcdc {e.Culture} entrou na Era: {e.Name} (Início: {e.StartYear}) | Gatilho: {e.Trigger}");
+    }
+}

--- a/src/UltraWorldAI/Time/GlobalEventSystem.cs
+++ b/src/UltraWorldAI/Time/GlobalEventSystem.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Time;
+
+public class GlobalEvent
+{
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public int YearOccurred { get; set; }
+    public string Impact { get; set; } = string.Empty;
+}
+
+public static class GlobalEventSystem
+{
+    public static List<GlobalEvent> Events { get; } = new();
+
+    public static void TriggerEvent(string name, string type, string impact)
+    {
+        var year = EraTimelineSystem.GlobalYear;
+        Events.Add(new GlobalEvent
+        {
+            Name = name,
+            Type = type,
+            Impact = impact,
+            YearOccurred = year
+        });
+
+        Console.WriteLine($"\u2604\ufe0f Evento Global: {name} ({type}) ocorreu no ano {year} | Efeito: {impact}");
+    }
+
+    public static void PrintEvents()
+    {
+        foreach (var e in Events)
+            Console.WriteLine($"\n\ud83c\udf0d {e.Name} | Tipo: {e.Type} | Ano: {e.YearOccurred} | Impacto: {e.Impact}");
+    }
+}

--- a/src/UltraWorldAI/Time/HistoryAndLegacySystem.cs
+++ b/src/UltraWorldAI/Time/HistoryAndLegacySystem.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Time;
+
+public class HistoryRecord
+{
+    public string Entity { get; set; } = string.Empty;
+    public string Event { get; set; } = string.Empty;
+    public int Year { get; set; }
+}
+
+public class LegacyTag
+{
+    public string Entity { get; set; } = string.Empty;
+    public string Tag { get; set; } = string.Empty;
+}
+
+public static class HistoryAndLegacySystem
+{
+    public static List<HistoryRecord> History { get; } = new();
+    public static List<LegacyTag> Legacies { get; } = new();
+
+    public static void AddRecord(string entity, string description)
+    {
+        History.Add(new HistoryRecord
+        {
+            Entity = entity,
+            Event = description,
+            Year = EraTimelineSystem.GlobalYear
+        });
+
+        Console.WriteLine($"\ud83d\udcd6 Registro: {entity} \u2014 {description} (Ano {EraTimelineSystem.GlobalYear})");
+    }
+
+    public static void AssignLegacy(string entity, string tag)
+    {
+        Legacies.Add(new LegacyTag
+        {
+            Entity = entity,
+            Tag = tag
+        });
+
+        Console.WriteLine($"\ud83c\udfdb\ufe0f Legado atribuído: {entity} \u2014 \"{tag}\"");
+    }
+
+    public static void PrintHistory()
+    {
+        foreach (var h in History)
+            Console.WriteLine($"\n\ud83d\udd6e {h.Entity} | {h.Event} | Ano {h.Year}");
+    }
+
+    public static void PrintLegacies()
+    {
+        foreach (var l in Legacies)
+            Console.WriteLine($"\n\ud83d\uddfe {l.Entity} possui o legado: \"{l.Tag}\"");
+    }
+}


### PR DESCRIPTION
## Summary
- add timeline, event, and legacy systems under `Time`
- rename conflicting `TaxPolicy` class to `KingdomTaxPolicy` in `EconomicCorruptionSystem`

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6843573e357c83238a9c052c580d431b