### PR TITLE
Add magical disease and living medical tech systems

### DIFF
--- a/src/UltraWorldAI/Module13/LivingMedicalTechSystem.cs
+++ b/src/UltraWorldAI/Module13/LivingMedicalTechSystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module13;
+
+public class LivingMedicalDevice
+{
+    public string Name = string.Empty;
+    public string Function = string.Empty; // "Regenera\u00e7\u00e3o", "Filtragem de veneno"
+    public string Form = string.Empty; // "Vermes curativos", "L\u00edquido simb\u00f3tico"
+    public bool Sentient;
+}
+
+public static class LivingMedicalTechSystem
+{
+    public static List<LivingMedicalDevice> Devices { get; } = new();
+
+    public static void AddDevice(string name, string function, string form, bool sentient)
+    {
+        Devices.Add(new LivingMedicalDevice
+        {
+            Name = name,
+            Function = function,
+            Form = form,
+            Sentient = sentient
+        });
+
+        Console.WriteLine($"\uD83E\uDDA7 Tecnologia viva: {name} | Fun\u00e7\u00e3o: {function} | Forma: {form} | Consciente? {sentient}");
+    }
+
+    public static void PrintDevices()
+    {
+        foreach (var d in Devices)
+            Console.WriteLine($"\uD83E\uDDE2 {d.Name} | Fun\u00e7\u00e3o: {d.Function} | Forma: {d.Form} | Consciente: {d.Sentient}");
+    }
+}

--- a/src/UltraWorldAI/Module13/MagicalDiseaseSystem.cs
+++ b/src/UltraWorldAI/Module13/MagicalDiseaseSystem.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module13;
+
+public class MagicalDisease
+{
+    public string Name = string.Empty;
+    public string Origin = string.Empty; // "Maldi\u00e7\u00e3o", "Plano da N\u00e9voa", "Deus Esquecido"
+    public string Symptom = string.Empty; // "Sangue canta", "Pele cristaliza"
+    public float SpreadRate;
+    public bool IsCultural;
+}
+
+public static class MagicalDiseaseSystem
+{
+    public static List<MagicalDisease> Diseases { get; } = new();
+
+    public static void AddDisease(string name, string origin, string symptom, float spreadRate, bool cultural)
+    {
+        Diseases.Add(new MagicalDisease
+        {
+            Name = name,
+            Origin = origin,
+            Symptom = symptom,
+            SpreadRate = spreadRate,
+            IsCultural = cultural
+        });
+
+        Console.WriteLine($"\uD83E\uDEC0 Doen\u00e7a m\u00e1gica: {name} | Origem: {origin} | Sintoma: {symptom} | Cont\u00e1gio: {spreadRate} | Cultural: {cultural}");
+    }
+
+    public static void PrintDiseases()
+    {
+        foreach (var d in Diseases)
+            Console.WriteLine($"\u2623\uFE0F {d.Name} | Origem: {d.Origin} | Sintoma: {d.Symptom} | Cont\u00e1gio: {d.SpreadRate} | Cultural: {d.IsCultural}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/MagicalDiseaseAndLivingTechSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MagicalDiseaseAndLivingTechSystemTests.cs
@@ -1,0 +1,21 @@
+using UltraWorldAI.Module13;
+using Xunit;
+
+public class MagicalDiseaseAndLivingTechSystemTests
+{
+    [Fact]
+    public void AddDiseaseStoresDisease()
+    {
+        MagicalDiseaseSystem.Diseases.Clear();
+        MagicalDiseaseSystem.AddDisease("Choro", "Plano", "Brilho", 0.3f, true);
+        Assert.Contains(MagicalDiseaseSystem.Diseases, d => d.Name == "Choro");
+    }
+
+    [Fact]
+    public void AddDeviceStoresDevice()
+    {
+        LivingMedicalTechSystem.Devices.Clear();
+        LivingMedicalTechSystem.AddDevice("Cora\u00e7\u00e3o", "Regen", "\u00d3rg\u00e3o", true);
+        Assert.Contains(LivingMedicalTechSystem.Devices, d => d.Name == "Cora\u00e7\u00e3o");
+    }
+}


### PR DESCRIPTION
## Summary
- add MagicalDiseaseSystem to handle magical diseases
- add LivingMedicalTechSystem for sentient medical technology
- cover the new systems with unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439d3dd5e4832395e2bf8b11d76d4e