### PR TITLE
Add aesthetic expression module

### DIFF
--- a/src/UltraWorldAI/Module15/AestheticMagicSystem.cs
+++ b/src/UltraWorldAI/Module15/AestheticMagicSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class AestheticSpell
+{
+    public string Artist = string.Empty;
+    public string ArtForm = string.Empty;
+    public string Effect = string.Empty;
+    public float Potency;
+}
+
+public static class AestheticMagicSystem
+{
+    public static List<AestheticSpell> Spells { get; } = new();
+
+    public static void CreateSpell(string artist, string artForm, string effect, float potency)
+    {
+        Spells.Add(new AestheticSpell
+        {
+            Artist = artist,
+            ArtForm = artForm,
+            Effect = effect,
+            Potency = potency
+        });
+
+        Console.WriteLine($"\uD83D\uDDFF Arte m\u00E1gica de {artist} em {artForm}: {effect} (Pot\u00EAncia: {potency})");
+    }
+
+    public static List<AestheticSpell> AllSpells() => Spells;
+}

--- a/src/UltraWorldAI/Module15/AestheticReactionSystem.cs
+++ b/src/UltraWorldAI/Module15/AestheticReactionSystem.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class AestheticProfile
+{
+    public string Name = string.Empty;
+    public Dictionary<string, float> Sensitivities = new();
+}
+
+public static class AestheticReactionSystem
+{
+    public static List<AestheticProfile> Profiles { get; } = new();
+
+    public static void RegisterProfile(string name, Dictionary<string, float> sensitivities)
+    {
+        Profiles.Add(new AestheticProfile
+        {
+            Name = name,
+            Sensitivities = sensitivities
+        });
+
+        Console.WriteLine($"\uD83C\uDFA8 Est\u00E9tica de {name} registrada.");
+    }
+
+    public static float Evaluate(string name, Dictionary<string, float> stimulus)
+    {
+        var profile = Profiles.Find(p => p.Name == name);
+        float total = 0;
+        if (profile != null)
+        {
+            foreach (var s in stimulus)
+            {
+                if (profile.Sensitivities.ContainsKey(s.Key))
+                    total += profile.Sensitivities[s.Key] * s.Value;
+            }
+        }
+        return total;
+    }
+}

--- a/src/UltraWorldAI/Module15/ArtisticExpressionSystem.cs
+++ b/src/UltraWorldAI/Module15/ArtisticExpressionSystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class ArtisticWork
+{
+    public string Author = string.Empty;
+    public string Medium = string.Empty;
+    public string Theme = string.Empty;
+    public float Intensity;
+}
+
+public static class ArtisticExpressionSystem
+{
+    public static List<ArtisticWork> Artworks { get; } = new();
+
+    public static void CreateWork(string author, string medium, string theme, float intensity)
+    {
+        Artworks.Add(new ArtisticWork
+        {
+            Author = author,
+            Medium = medium,
+            Theme = theme,
+            Intensity = intensity
+        });
+
+        Console.WriteLine($"\uD83D\uDD8C\uFE0F {author} criou uma obra em {medium} com o tema: {theme} (Intensidade: {intensity})");
+    }
+
+    public static void PrintGallery()
+    {
+        foreach (var a in Artworks)
+            Console.WriteLine($"\uD83C\uDFAD {a.Author} \u2192 {a.Medium} | Tema: {a.Theme} | Intensidade: {a.Intensity}");
+    }
+}

--- a/src/UltraWorldAI/Module15/DynamicMusicSystem.cs
+++ b/src/UltraWorldAI/Module15/DynamicMusicSystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Module15;
+
+public class Song
+{
+    public string Composer = string.Empty;
+    public string Title = string.Empty;
+    public string Mood = string.Empty;
+    public float Intensity;
+}
+
+public static class DynamicMusicSystem
+{
+    public static List<Song> Songs { get; } = new();
+
+    public static void ComposeSong(string composer, string title, string mood, float intensity)
+    {
+        Songs.Add(new Song
+        {
+            Composer = composer,
+            Title = title,
+            Mood = mood,
+            Intensity = intensity
+        });
+
+        Console.WriteLine($"\uD83C\uDFB5 {composer} comp\u00F4s '{title}' em tom {mood} (Intensidade: {intensity})");
+    }
+
+    public static Song? GetMostIntense(string mood)
+    {
+        return Songs.Where(s => s.Mood == mood).OrderByDescending(s => s.Intensity).FirstOrDefault();
+    }
+}

--- a/src/UltraWorldAI/Module15/LiteraryCreationSystem.cs
+++ b/src/UltraWorldAI/Module15/LiteraryCreationSystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class LiteraryWork
+{
+    public string Author = string.Empty;
+    public string Form = string.Empty; // poema, teatro, etc.
+    public string Tone = string.Empty; // sarc\u00E1stico, ir\u00F4nico
+    public string Excerpt = string.Empty;
+}
+
+public static class LiteraryCreationSystem
+{
+    public static List<LiteraryWork> Works { get; } = new();
+
+    public static void Write(string author, string form, string tone, string excerpt)
+    {
+        Works.Add(new LiteraryWork
+        {
+            Author = author,
+            Form = form,
+            Tone = tone,
+            Excerpt = excerpt
+        });
+
+        Console.WriteLine($"\uD83D\uDCDD {author} escreveu {form} ({tone})");
+    }
+
+    public static void PrintWorks()
+    {
+        foreach (var w in Works)
+            Console.WriteLine($"\uD83D\uDCD6 {w.Author} \u2013 {w.Form} ({w.Tone}): {w.Excerpt}");
+    }
+}

--- a/src/UltraWorldAI/Module15/PersonalStyleSystem.cs
+++ b/src/UltraWorldAI/Module15/PersonalStyleSystem.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class StyleProfile
+{
+    public string Name = string.Empty;
+    public List<string> PreferredElements = new();
+    public string DominantMood = string.Empty;
+}
+
+public static class PersonalStyleSystem
+{
+    public static List<StyleProfile> Styles { get; } = new();
+
+    public static void DefineStyle(string name, List<string> elements, string mood)
+    {
+        Styles.Add(new StyleProfile
+        {
+            Name = name,
+            PreferredElements = elements,
+            DominantMood = mood
+        });
+
+        Console.WriteLine($"\uD83D\uDC57 Estilo de {name}: {string.Join(", ", elements)} | Clima: {mood}");
+    }
+
+    public static void PrintStyles()
+    {
+        foreach (var s in Styles)
+            Console.WriteLine($"\uD83E\uDDF5 {s.Name} | Elementos: {string.Join(", ", s.PreferredElements)} | Estilo: {s.DominantMood}");
+    }
+}

--- a/src/UltraWorldAI/Module15/StyleInheritanceSystem.cs
+++ b/src/UltraWorldAI/Module15/StyleInheritanceSystem.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace UltraWorldAI.Module15;
+
+public static class StyleInheritanceSystem
+{
+    public static string InheritStyle(string parentStyle, string descendant)
+    {
+        var newStyle = $"{parentStyle} ({descendant})";
+        Console.WriteLine($"\uD83E\uDDE9 {descendant} herdou o estilo: {parentStyle}");
+        return newStyle;
+    }
+}

--- a/tests/UltraWorldAI.Tests/AestheticMagicSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/AestheticMagicSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class AestheticMagicSystemTests
+{
+    [Fact]
+    public void CreateSpellRegistersSpell()
+    {
+        AestheticMagicSystem.Spells.Clear();
+        AestheticMagicSystem.CreateSpell("Ana", "Dança", "Curar", 1f);
+        Assert.Contains(AestheticMagicSystem.Spells, s => s.Artist == "Ana" && s.ArtForm == "Dança");
+    }
+}

--- a/tests/UltraWorldAI.Tests/AestheticReactionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/AestheticReactionSystemTests.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class AestheticReactionSystemTests
+{
+    [Fact]
+    public void EvaluateReturnsWeightedSum()
+    {
+        AestheticReactionSystem.Profiles.Clear();
+        AestheticReactionSystem.RegisterProfile("Ana", new() { { "Cor", 0.5f } });
+        var score = AestheticReactionSystem.Evaluate("Ana", new() { { "Cor", 2f } });
+        Assert.Equal(1f, score);
+    }
+}

--- a/tests/UltraWorldAI.Tests/ArtisticExpressionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ArtisticExpressionSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class ArtisticExpressionSystemTests
+{
+    [Fact]
+    public void CreateWorkAddsArtwork()
+    {
+        ArtisticExpressionSystem.Artworks.Clear();
+        ArtisticExpressionSystem.CreateWork("Ana", "Pintura", "Luz", 0.7f);
+        Assert.Contains(ArtisticExpressionSystem.Artworks, a => a.Author == "Ana" && a.Medium == "Pintura");
+    }
+}

--- a/tests/UltraWorldAI.Tests/DynamicMusicSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DynamicMusicSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class DynamicMusicSystemTests
+{
+    [Fact]
+    public void ComposeSongAddsSong()
+    {
+        DynamicMusicSystem.Songs.Clear();
+        DynamicMusicSystem.ComposeSong("Ana", "Melodia", "Feliz", 0.9f);
+        Assert.Contains(DynamicMusicSystem.Songs, s => s.Title == "Melodia" && s.Composer == "Ana");
+    }
+}

--- a/tests/UltraWorldAI.Tests/LiteraryCreationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/LiteraryCreationSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class LiteraryCreationSystemTests
+{
+    [Fact]
+    public void WriteAddsWork()
+    {
+        LiteraryCreationSystem.Works.Clear();
+        LiteraryCreationSystem.Write("Ana", "Poema", "Irônico", "Trecho");
+        Assert.Contains(LiteraryCreationSystem.Works, w => w.Form == "Poema" && w.Author == "Ana");
+    }
+}

--- a/tests/UltraWorldAI.Tests/PersonalStyleSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PersonalStyleSystemTests.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class PersonalStyleSystemTests
+{
+    [Fact]
+    public void DefineStyleStoresProfile()
+    {
+        PersonalStyleSystem.Styles.Clear();
+        PersonalStyleSystem.DefineStyle("Ana", new List<string> { "Brilho" }, "Elegante");
+        Assert.Contains(PersonalStyleSystem.Styles, s => s.Name == "Ana" && s.DominantMood == "Elegante");
+    }
+}

--- a/tests/UltraWorldAI.Tests/StyleInheritanceSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/StyleInheritanceSystemTests.cs
@@ -1,0 +1,12 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class StyleInheritanceSystemTests
+{
+    [Fact]
+    public void InheritStyleReturnsCombinedName()
+    {
+        var style = StyleInheritanceSystem.InheritStyle("Clássico", "TriboA");
+        Assert.Equal("Clássico (TriboA)", style);
+    }
+}


### PR DESCRIPTION
## Summary
- add Module15 with aesthetic reaction, artistic expression and personal style systems
- support dynamic music creation and magical aesthetic effects
- allow literary creation and style inheritance
- test new emotion and art systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442673066483238c321a3f92052fa9