### PR TITLE
Add emotion and aesthetic social systems

### DIFF
--- a/src/UltraWorldAI/Module15/ForbiddenArtSystem.cs
+++ b/src/UltraWorldAI/Module15/ForbiddenArtSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class ForbiddenWork
+{
+    public string Title = string.Empty;
+    public string Creator = string.Empty;
+    public string Reason = string.Empty; // "Perigosa", "Blasfema", "Mágica demais", "Traiçoeira"
+    public bool StillExists;
+    public string Location = string.Empty; // "Ruínas", "Caverna Selada", "Santuário Secreto"
+}
+
+public static class ForbiddenArtSystem
+{
+    public static List<ForbiddenWork> Works { get; } = new();
+
+    public static void AddForbiddenWork(string title, string creator, string reason, bool exists, string location)
+    {
+        Works.Add(new ForbiddenWork
+        {
+            Title = title,
+            Creator = creator,
+            Reason = reason,
+            StillExists = exists,
+            Location = location
+        });
+
+        Console.WriteLine($"\uD83D\uDD11 Obra proibida: {title} | Razão: {reason} | Onde está? {location} | Existe? {exists}");
+    }
+}

--- a/src/UltraWorldAI/Module15/LiteraryExpressionSystem.cs
+++ b/src/UltraWorldAI/Module15/LiteraryExpressionSystem.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace UltraWorldAI.Module15;
 
-public class LiteraryWork
+public class ExpressiveWork
 {
     public string Author = string.Empty;
     public string Genre = string.Empty;
@@ -13,11 +13,11 @@ public class LiteraryWork
 
 public static class LiteraryExpressionSystem
 {
-    public static List<LiteraryWork> Works { get; } = new();
+    public static List<ExpressiveWork> Works { get; } = new();
 
     public static void CreateWork(string author, string genre, string theme, string style)
     {
-        Works.Add(new LiteraryWork
+        Works.Add(new ExpressiveWork
         {
             Author = author,
             Genre = genre,

--- a/src/UltraWorldAI/Module15/PerformanceSocialSystem.cs
+++ b/src/UltraWorldAI/Module15/PerformanceSocialSystem.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class PerformanceGroup
+{
+    public string Name = string.Empty;
+    public List<string> Members = new();
+    public string Form = string.Empty; // "Coro cerimonial", "Dueto profético", "Encenação pública"
+    public string Purpose = string.Empty; // "Invocar", "Comover", "Educar", "Celebrar"
+}
+
+public static class PerformanceSocialSystem
+{
+    public static List<PerformanceGroup> Groups { get; } = new();
+
+    public static void CreatePerformance(string name, List<string> members, string form, string purpose)
+    {
+        Groups.Add(new PerformanceGroup
+        {
+            Name = name,
+            Members = members,
+            Form = form,
+            Purpose = purpose
+        });
+
+        Console.WriteLine($"\uD83C\uDFA4 Performance criada: {name} | Forma: {form} | Finalidade: {purpose}");
+    }
+}

--- a/src/UltraWorldAI/Module15/SacredAestheticSystem.cs
+++ b/src/UltraWorldAI/Module15/SacredAestheticSystem.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class SacredForm
+{
+    public string Culture = string.Empty;
+    public string SacredStyle = string.Empty; // "Minimalismo lunar", "Ouro simbólico", "Cor apagada"
+    public string Function = string.Empty; // "Ritual de passagem", "Arte devocional", "Meditação visual"
+}
+
+public static class SacredAestheticSystem
+{
+    public static List<SacredForm> SacredStyles { get; } = new();
+
+    public static void AddSacredAesthetic(string culture, string style, string function)
+    {
+        SacredStyles.Add(new SacredForm
+        {
+            Culture = culture,
+            SacredStyle = style,
+            Function = function
+        });
+
+        Console.WriteLine($"\uD83D\uDD6F\uFE0F Estética sagrada de {culture} | Estilo: {style} | Função: {function}");
+    }
+}

--- a/src/UltraWorldAI/Module15/StyleConflictSystem.cs
+++ b/src/UltraWorldAI/Module15/StyleConflictSystem.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class AestheticFaction
+{
+    public string SchoolName = string.Empty;
+    public string CoreSymbol = string.Empty; // "Caos visual", "Perfeição simétrica"
+    public List<string> Opposes = new(); // Nomes de escolas rivais
+    public string ArtisticPhilosophy = string.Empty;
+}
+
+public static class StyleConflictSystem
+{
+    public static List<AestheticFaction> Factions { get; } = new();
+
+    public static void AddSchool(string name, string symbol, List<string> enemies, string philosophy)
+    {
+        Factions.Add(new AestheticFaction
+        {
+            SchoolName = name,
+            CoreSymbol = symbol,
+            Opposes = enemies,
+            ArtisticPhilosophy = philosophy
+        });
+
+        Console.WriteLine($"\u2694\uFE0F Escola estética: {name} | Contra: {string.Join(", ", enemies)} | Filosofia: {philosophy}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/ForbiddenArtSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ForbiddenArtSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class ForbiddenArtSystemTests
+{
+    [Fact]
+    public void AddForbiddenWorkRegistersWork()
+    {
+        ForbiddenArtSystem.Works.Clear();
+        ForbiddenArtSystem.AddForbiddenWork("Eco", "Anon", "Perigosa", true, "Ruínas");
+        Assert.Contains(ForbiddenArtSystem.Works, w => w.Title == "Eco" && w.Creator == "Anon" && w.Reason == "Perigosa" && w.StillExists && w.Location == "Ruínas");
+    }
+}

--- a/tests/UltraWorldAI.Tests/PerformanceSocialSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PerformanceSocialSystemTests.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class PerformanceSocialSystemTests
+{
+    [Fact]
+    public void CreatePerformanceAddsGroup()
+    {
+        PerformanceSocialSystem.Groups.Clear();
+        PerformanceSocialSystem.CreatePerformance("Lamentos", new List<string> {"A", "B"}, "Coro", "Invocar");
+        Assert.Contains(PerformanceSocialSystem.Groups, g => g.Name == "Lamentos" && g.Members.Contains("A") && g.Form == "Coro" && g.Purpose == "Invocar");
+    }
+}

--- a/tests/UltraWorldAI.Tests/SacredAestheticSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/SacredAestheticSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class SacredAestheticSystemTests
+{
+    [Fact]
+    public void AddSacredAestheticRegistersForm()
+    {
+        SacredAestheticSystem.SacredStyles.Clear();
+        SacredAestheticSystem.AddSacredAesthetic("Tribo", "Ouro", "Ritual");
+        Assert.Contains(SacredAestheticSystem.SacredStyles, s => s.Culture == "Tribo" && s.SacredStyle == "Ouro" && s.Function == "Ritual");
+    }
+}

--- a/tests/UltraWorldAI.Tests/StyleConflictSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/StyleConflictSystemTests.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class StyleConflictSystemTests
+{
+    [Fact]
+    public void AddSchoolAddsFaction()
+    {
+        StyleConflictSystem.Factions.Clear();
+        StyleConflictSystem.AddSchool("Caos", "Simbolo", new List<string> { "Ordem" }, "Ruptura");
+        Assert.Contains(StyleConflictSystem.Factions, f => f.SchoolName == "Caos" && f.CoreSymbol == "Simbolo" && f.Opposes.Contains("Ordem") && f.ArtisticPhilosophy == "Ruptura");
+    }
+}


### PR DESCRIPTION
## Summary
- implement PerformanceSocialSystem for collaborative rituals
- implement SacredAestheticSystem for sacred styles
- implement StyleConflictSystem for rival aesthetic schools
- implement ForbiddenArtSystem tracking lost or banned works
- adjust LiteraryExpressionSystem to use `ExpressiveWork`
- add unit tests covering the new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68442b8c386c832380c6243c83998265