### PR TITLE
Add religious and weaponized art systems

### DIFF
--- a/src/UltraWorldAI/Module15/ArtAsWeaponSystem.cs
+++ b/src/UltraWorldAI/Module15/ArtAsWeaponSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class WeaponizedArt
+{
+    public string Title = string.Empty;
+    public string Faction = string.Empty;
+    public string Medium = string.Empty; // "Peça teatral", "Grafite", "Música", "Cartaz mágico"
+    public string Target = string.Empty; // "Império do Norte", "Sacerdotes da Estase"
+    public string Purpose = string.Empty; // "Profetizar queda", "Difamar", "Despertar levante"
+}
+
+public static class ArtAsWeaponSystem
+{
+    public static List<WeaponizedArt> Campaigns { get; } = new();
+
+    public static void DeployArt(string title, string faction, string medium, string target, string purpose)
+    {
+        Campaigns.Add(new WeaponizedArt
+        {
+            Title = title,
+            Faction = faction,
+            Medium = medium,
+            Target = target,
+            Purpose = purpose
+        });
+
+        Console.WriteLine($"\u2694\uFE0F Arte usada como arma: {title} | Contra: {target} | Finalidade: {purpose}");
+    }
+}

--- a/src/UltraWorldAI/Module15/ReligiousArtSystem.cs
+++ b/src/UltraWorldAI/Module15/ReligiousArtSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module15;
+
+public class ReligiousArt
+{
+    public string Title = string.Empty;
+    public string Creator = string.Empty;
+    public string AssociatedFaith = string.Empty; // "Culto do Vazio", "Doutrina da Chama"
+    public string Type = string.Empty; // "Ícone", "Mural", "Estátua", "Poesia sagrada"
+    public string DoctrinalMessage = string.Empty; // "A carne é passageira", "O silêncio é pureza"
+}
+
+public static class ReligiousArtSystem
+{
+    public static List<ReligiousArt> Works { get; } = new();
+
+    public static void AddReligiousArt(string title, string creator, string faith, string type, string message)
+    {
+        Works.Add(new ReligiousArt
+        {
+            Title = title,
+            Creator = creator,
+            AssociatedFaith = faith,
+            Type = type,
+            DoctrinalMessage = message
+        });
+
+        Console.WriteLine($"\uD83D\uDD4A\uFE0F Arte doutrin\u00E1ria: {title} | F\u00E9: {faith} | Mensagem: {message}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/ArtAsWeaponSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ArtAsWeaponSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class ArtAsWeaponSystemTests
+{
+    [Fact]
+    public void DeployArtRegistersCampaign()
+    {
+        ArtAsWeaponSystem.Campaigns.Clear();
+        ArtAsWeaponSystem.DeployArt("Traidor", "Resistência", "Peça", "Império", "Despertar");
+        Assert.Contains(ArtAsWeaponSystem.Campaigns, c => c.Title == "Traidor" && c.Faction == "Resistência" && c.Medium == "Peça" && c.Target == "Império" && c.Purpose == "Despertar");
+    }
+}

--- a/tests/UltraWorldAI.Tests/ReligiousArtSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ReligiousArtSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class ReligiousArtSystemTests
+{
+    [Fact]
+    public void AddReligiousArtRegistersWork()
+    {
+        ReligiousArtSystem.Works.Clear();
+        ReligiousArtSystem.AddReligiousArt("Olhos", "Kael", "Doutrina", "Ícone", "A voz é queda");
+        Assert.Contains(ReligiousArtSystem.Works, w => w.Title == "Olhos" && w.Creator == "Kael" && w.AssociatedFaith == "Doutrina" && w.Type == "Ícone" && w.DoctrinalMessage == "A voz é queda");
+    }
+}


### PR DESCRIPTION
## Summary
- create `ReligiousArtSystem` for doctrinal art
- create `ArtAsWeaponSystem` for propaganda and political art
- cover the new systems with unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68442d49cf648323b82dc480282d0222