### PR TITLE
Add emotional union and desire systems

### DIFF
--- a/src/UltraWorldAI/Relationships/EmotionalMarriageSystem.cs
+++ b/src/UltraWorldAI/Relationships/EmotionalMarriageSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Relationships;
+
+public class EmotionalUnion
+{
+    public string PartnerA = string.Empty;
+    public string PartnerB = string.Empty;
+    public string UnionType = string.Empty; // "Casamento cerimonial", "Pacto de sangue", "União de almas"
+    public List<string> Vows = new(); // "Nunca partir", "Gerar filhos na lua cheia"
+    public bool InheritedEmotion;
+}
+
+public static class EmotionalMarriageSystem
+{
+    public static List<EmotionalUnion> Unions { get; } = new();
+
+    public static void FormUnion(string a, string b, string type, List<string> vows, bool inherited)
+    {
+        Unions.Add(new EmotionalUnion
+        {
+            PartnerA = a,
+            PartnerB = b,
+            UnionType = type,
+            Vows = vows,
+            InheritedEmotion = inherited
+        });
+
+        Console.WriteLine($"\uD83D\uDC8D União entre {a} e {b} | Tipo: {type} | Votos: {string.Join(", ", vows)}");
+    }
+}

--- a/src/UltraWorldAI/Relationships/UnconsciousDesireSystem.cs
+++ b/src/UltraWorldAI/Relationships/UnconsciousDesireSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Relationships;
+
+public class UnconsciousBond
+{
+    public string Subject = string.Empty;
+    public string Target = string.Empty;
+    public string Type = string.Empty; // "Desejo inconsciente", "Amor platônico", "Rivalidade afetiva"
+    public float EmotionalWeight;
+    public bool Aware;
+}
+
+public static class UnconsciousDesireSystem
+{
+    public static List<UnconsciousBond> HiddenBonds { get; } = new();
+
+    public static void CreateBond(string subject, string target, string type, float weight, bool aware)
+    {
+        HiddenBonds.Add(new UnconsciousBond
+        {
+            Subject = subject,
+            Target = target,
+            Type = type,
+            EmotionalWeight = weight,
+            Aware = aware
+        });
+
+        Console.WriteLine($"\uD83C\uDF00 {subject} → {target} | Tipo: {type} | Intensidade: {weight} | Consciente? {aware}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/EmotionalMarriageSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/EmotionalMarriageSystemTests.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using UltraWorldAI.Relationships;
+using Xunit;
+
+public class EmotionalMarriageSystemTests
+{
+    [Fact]
+    public void FormUnionAddsUnion()
+    {
+        EmotionalMarriageSystem.Unions.Clear();
+        EmotionalMarriageSystem.FormUnion(
+            "Kael",
+            "Saren",
+            "União de almas",
+            new List<string> { "Não esconder segredos" },
+            true);
+
+        Assert.Contains(EmotionalMarriageSystem.Unions,
+            u => u.PartnerA == "Kael" && u.PartnerB == "Saren" && u.InheritedEmotion);
+    }
+}

--- a/tests/UltraWorldAI.Tests/UnconsciousDesireSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/UnconsciousDesireSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Relationships;
+using Xunit;
+
+public class UnconsciousDesireSystemTests
+{
+    [Fact]
+    public void CreateBondAddsHiddenBond()
+    {
+        UnconsciousDesireSystem.HiddenBonds.Clear();
+        UnconsciousDesireSystem.CreateBond("Kael", "Raela", "Desejo inconsciente", 0.75f, false);
+
+        Assert.Contains(UnconsciousDesireSystem.HiddenBonds,
+            b => b.Subject == "Kael" && b.Target == "Raela" && !b.Aware);
+    }
+}


### PR DESCRIPTION
## Summary
- add emotional marriage unions with vows
- add hidden unconscious desire bonds
- test emotional marriage system
- test unconscious desire system

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442f3972ec8323b2dcfa688b50e1fc