### PR TITLE
Add new knowledge and literature systems

### DIFF
--- a/src/UltraWorldAI/Knowledge/ForbiddenKnowledgeNetwork.cs
+++ b/src/UltraWorldAI/Knowledge/ForbiddenKnowledgeNetwork.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Knowledge;
+
+public class SecretNetwork
+{
+    public string Name = string.Empty;
+    public List<string> Members = new();
+    public List<string> HiddenTopics = new();
+    public string AccessMethod = string.Empty; // "Código", "Ritual", "Alinhamento ideológico"
+    public List<string> PoliticalAlliances = new();
+    public List<string> MagicalPacts = new();
+    public List<string> SupportedRebellions = new();
+}
+
+public static class ForbiddenKnowledgeNetwork
+{
+    public static List<SecretNetwork> Networks { get; } = new();
+
+    public static void CreateNetwork(string name, List<string> members, List<string> topics, string method)
+    {
+        Networks.Add(new SecretNetwork
+        {
+            Name = name,
+            Members = members,
+            HiddenTopics = topics,
+            AccessMethod = method
+        });
+
+        Console.WriteLine($"\ud83d\udd75\ufe0f Rede secreta criada: {name} | Método de acesso: {method} | Saberes ocultos: {topics.Count}");
+    }
+
+    public static void InfluencePolitics(string name, string faction)
+    {
+        var net = Networks.Find(n => n.Name == name);
+        if (net == null) return;
+        if (!net.PoliticalAlliances.Contains(faction))
+            net.PoliticalAlliances.Add(faction);
+
+        Console.WriteLine($"\ud83c\udfdb\ufe0f Rede {name} influenciou a política de {faction}");
+    }
+
+    public static void ForgeMagicalPact(string name, string pact)
+    {
+        var net = Networks.Find(n => n.Name == name);
+        if (net == null) return;
+        if (!net.MagicalPacts.Contains(pact))
+            net.MagicalPacts.Add(pact);
+
+        Console.WriteLine($"\u2728 Rede {name} selou pacto mágico: {pact}");
+    }
+
+    public static void SupportRebellion(string name, string rebellion)
+    {
+        var net = Networks.Find(n => n.Name == name);
+        if (net == null) return;
+        if (!net.SupportedRebellions.Contains(rebellion))
+            net.SupportedRebellions.Add(rebellion);
+
+        Console.WriteLine($"\u2694\ufe0f Rede {name} apoiou rebelião: {rebellion}");
+    }
+}

--- a/src/UltraWorldAI/Knowledge/KnowledgeLineageSystem.cs
+++ b/src/UltraWorldAI/Knowledge/KnowledgeLineageSystem.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Knowledge;
+
+public class KnowledgeLineage
+{
+    public string Founder = string.Empty;
+    public string SchoolName = string.Empty;
+    public List<string> Descendants = new();
+    public bool IsHeretical;
+    public string CoreBelief = string.Empty;
+    public int Hunts;
+    public int Wars;
+    public int Purifications;
+}
+
+public static class KnowledgeLineageSystem
+{
+    public static List<KnowledgeLineage> Schools { get; } = new();
+
+    public static void RegisterLineage(
+        string founder,
+        string name,
+        List<string> descendants,
+        bool heresy,
+        string belief)
+    {
+        Schools.Add(new KnowledgeLineage
+        {
+            Founder = founder,
+            SchoolName = name,
+            Descendants = descendants,
+            IsHeretical = heresy,
+            CoreBelief = belief
+        });
+
+        Console.WriteLine($"\ud83c\udfdb\ufe0f Escola '{name}' fundada por {founder} | Herética? {heresy} | Doutrina: {belief}");
+    }
+
+    public static void AddRepressionEvent(string school, string type)
+    {
+        var s = Schools.Find(sc => sc.SchoolName == school);
+        if (s == null) return;
+
+        switch (type)
+        {
+            case "caça":
+                s.Hunts++;
+                break;
+            case "guerra":
+                s.Wars++;
+                break;
+            case "purificação":
+                s.Purifications++;
+                break;
+        }
+
+        Console.WriteLine($"\u2694\ufe0f Evento '{type}' registrado contra a escola {school}");
+    }
+}

--- a/src/UltraWorldAI/Literature/BookCreationSystem.cs
+++ b/src/UltraWorldAI/Literature/BookCreationSystem.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Literature;
+
+public class Book
+{
+    public string Title = string.Empty;
+    public string Author = string.Empty;
+    public string Type = string.Empty; // "Livro científico", "Grimório", "Manuscrito filosófico"
+    public List<string> Topics = new();
+    public bool IsCursed;
+    public string OriginPlace = string.Empty;
+    public bool SelfWriting;
+    public bool BurnsOnRead;
+}
+
+public static class BookCreationSystem
+{
+    public static List<Book> Library { get; } = new();
+
+    public static void WriteBook(
+        string title,
+        string author,
+        string type,
+        List<string> topics,
+        bool cursed,
+        string origin,
+        bool selfWriting = false,
+        bool burnsOnRead = false)
+    {
+        Library.Add(new Book
+        {
+            Title = title,
+            Author = author,
+            Type = type,
+            Topics = topics,
+            IsCursed = cursed,
+            OriginPlace = origin,
+            SelfWriting = selfWriting,
+            BurnsOnRead = burnsOnRead
+        });
+
+        Console.WriteLine($"\ud83d\udcd6 Livro criado: '{title}' por {author} | Tipo: {type} | Amaldiçoado? {cursed}");
+    }
+
+    public static void ReadBook(string title)
+    {
+        var book = Library.Find(b => b.Title == title);
+        if (book == null) return;
+
+        if (book.SelfWriting)
+            Console.WriteLine($"\ud83d\udcdd O livro '{title}' continua se escrevendo sozinho...");
+
+        if (book.BurnsOnRead)
+        {
+            Console.WriteLine($"\ud83d\udd25 O livro '{title}' queimou ao ser lido!");
+            Library.Remove(book);
+            return;
+        }
+
+        if (book.IsCursed)
+            Console.WriteLine($"\u2620\ufe0f Você foi amaldiçoado ao ler '{title}'!");
+    }
+}

--- a/tests/UltraWorldAI.Tests/BookCreationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/BookCreationSystemTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UltraWorldAI.Literature;
+using Xunit;
+
+public class BookCreationSystemTests
+{
+    [Fact]
+    public void WriteBookAddsToLibrary()
+    {
+        BookCreationSystem.Library.Clear();
+        BookCreationSystem.WriteBook(
+            "Codice",
+            "Thalor",
+            "Grimório",
+            new List<string> { "Magia" },
+            true,
+            "Templo",
+            selfWriting: true,
+            burnsOnRead: false);
+
+        Assert.Single(BookCreationSystem.Library);
+    }
+
+    [Fact]
+    public void ReadBookBurnsWhenFlagged()
+    {
+        BookCreationSystem.Library.Clear();
+        BookCreationSystem.WriteBook(
+            "Fênix",
+            "Autor",
+            "Tratado",
+            new List<string>(),
+            false,
+            "Fornalha",
+            burnsOnRead: true);
+
+        BookCreationSystem.ReadBook("Fênix");
+        Assert.Empty(BookCreationSystem.Library);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/ForbiddenKnowledgeNetworkTests.cs
+++ b/tests/UltraWorldAI.Tests/ForbiddenKnowledgeNetworkTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using UltraWorldAI.Knowledge;
+using Xunit;
+
+public class ForbiddenKnowledgeNetworkTests
+{
+    [Fact]
+    public void CreateNetworkStoresNetwork()
+    {
+        ForbiddenKnowledgeNetwork.Networks.Clear();
+        ForbiddenKnowledgeNetwork.CreateNetwork(
+            "Veu",
+            new List<string>(),
+            new List<string>(),
+            "Codigo");
+        Assert.Single(ForbiddenKnowledgeNetwork.Networks);
+    }
+
+    [Fact]
+    public void InfluencePoliticsAddsAlliance()
+    {
+        ForbiddenKnowledgeNetwork.Networks.Clear();
+        ForbiddenKnowledgeNetwork.CreateNetwork(
+            "Veu",
+            new List<string>(),
+            new List<string>(),
+            "Codigo");
+        ForbiddenKnowledgeNetwork.InfluencePolitics("Veu", "Reino");
+        Assert.Contains("Reino", ForbiddenKnowledgeNetwork.Networks[0].PoliticalAlliances);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/KnowledgeLineageSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/KnowledgeLineageSystemTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using UltraWorldAI.Knowledge;
+using Xunit;
+
+public class KnowledgeLineageSystemTests
+{
+    [Fact]
+    public void RegisterLineageStoresSchool()
+    {
+        KnowledgeLineageSystem.Schools.Clear();
+        KnowledgeLineageSystem.RegisterLineage(
+            "Saren",
+            "Luz",
+            new List<string> { "Kael" },
+            true,
+            "Luz interior");
+
+        Assert.Single(KnowledgeLineageSystem.Schools);
+    }
+
+    [Fact]
+    public void AddRepressionEventIncrementsCounters()
+    {
+        KnowledgeLineageSystem.Schools.Clear();
+        KnowledgeLineageSystem.RegisterLineage("Saren", "Luz", new List<string>(), true, "");
+        KnowledgeLineageSystem.AddRepressionEvent("Luz", "caça");
+        KnowledgeLineageSystem.AddRepressionEvent("Luz", "guerra");
+
+        var school = KnowledgeLineageSystem.Schools[0];
+        Assert.Equal(1, school.Hunts);
+        Assert.Equal(1, school.Wars);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `BookCreationSystem` for magical tomes with burn and curse logic
- expand knowledge lineages to track repression events
- create a forbidden knowledge network with political and magical hooks
- test new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684435f5d9008323903981fe0294e86a