### PR TITLE
Add historical manipulation and metacognition integration

### DIFF
--- a/src/UltraWorldAI/KnowledgePersecution.cs
+++ b/src/UltraWorldAI/KnowledgePersecution.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UltraWorldAI;
 
 namespace UltraWorldAI.Discovery;
 
@@ -26,6 +27,12 @@ public static class KnowledgePersecution
             Date = DateTime.Now,
             IsRemembered = new Random().NextDouble() > 0.5
         });
+    }
+
+    public static void ForbidTechWithMetacognition(string techName, string by, string reason, MetacognitionSystem meta)
+    {
+        ForbidTech(techName, by, reason);
+        meta.RegisterForbiddenKnowledge(techName);
     }
 
     public static string DescribeAll()

--- a/src/UltraWorldAI/MetacognitionSystem.cs
+++ b/src/UltraWorldAI/MetacognitionSystem.cs
@@ -7,6 +7,7 @@ namespace UltraWorldAI
     {
         private readonly Person _person;
         public List<string> SelfImage { get; private set; } = new List<string>();
+        public List<string> ForbiddenKnowledge { get; } = new();
 
         public MetacognitionSystem(Person person)
         {
@@ -31,6 +32,15 @@ namespace UltraWorldAI
             if (SelfImage.Remove(aspect))
             {
                 Logger.Log($"[Metacognition] {_person.Name}'s self-image no longer includes: {aspect}");
+            }
+        }
+
+        public void RegisterForbiddenKnowledge(string techName)
+        {
+            if (!ForbiddenKnowledge.Contains(techName))
+            {
+                ForbiddenKnowledge.Add(techName);
+                AddToSelfImage($"questiona-{techName}");
             }
         }
     }

--- a/src/UltraWorldAI/Politics/HistoricalManipulationSystem.cs
+++ b/src/UltraWorldAI/Politics/HistoricalManipulationSystem.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Politics;
+
+public class HistoricalManipulation
+{
+    public string Record { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public string Action { get; set; } = string.Empty; // "ForgeTreaty", "RewriteHistory"
+    public string Intent { get; set; } = string.Empty;
+    public bool Success { get; set; }
+}
+
+public static class HistoricalManipulationSystem
+{
+    public static List<HistoricalManipulation> Actions { get; } = new();
+
+    public static void ForgeTreaty(string title, string issuer, string intent)
+    {
+        Actions.Add(new HistoricalManipulation
+        {
+            Record = title,
+            Source = issuer,
+            Action = "ForgeTreaty",
+            Intent = intent,
+            Success = true
+        });
+
+        RoyalDocumentSystem.IssueDocument(title, issuer, "Tratado", $"Intento: {intent}", true);
+    }
+
+    public static void RewriteHistory(string eventName, string actor, string intent, bool success)
+    {
+        Actions.Add(new HistoricalManipulation
+        {
+            Record = eventName,
+            Source = actor,
+            Action = "RewriteHistory",
+            Intent = intent,
+            Success = success
+        });
+
+        var result = success ? "alterado" : "exposto";
+        Console.WriteLine($"\uD83D\uDCDD Evento '{eventName}' {result} por {actor} (Motivo: {intent})");
+    }
+}

--- a/tests/UltraWorldAI.Tests/HistoricalManipulationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/HistoricalManipulationSystemTests.cs
@@ -1,0 +1,13 @@
+using UltraWorldAI.Politics;
+using Xunit;
+
+public class HistoricalManipulationSystemTests
+{
+    [Fact]
+    public void ForgeTreatyAddsAction()
+    {
+        HistoricalManipulationSystem.Actions.Clear();
+        HistoricalManipulationSystem.ForgeTreaty("Pacto", "Lorde", "ganhar territorio");
+        Assert.Single(HistoricalManipulationSystem.Actions);
+    }
+}

--- a/tests/UltraWorldAI.Tests/MetacognitionKnowledgeIntegrationTests.cs
+++ b/tests/UltraWorldAI.Tests/MetacognitionKnowledgeIntegrationTests.cs
@@ -1,0 +1,19 @@
+using UltraWorldAI;
+using UltraWorldAI.Discovery;
+using Xunit;
+
+public class MetacognitionKnowledgeIntegrationTests
+{
+    [Fact]
+    public void ForbidTechUpdatesMetacognition()
+    {
+        var person = new Person("Elias");
+        var meta = new MetacognitionSystem(person);
+        KnowledgePersecution.Blacklist.Clear();
+
+        KnowledgePersecution.ForbidTechWithMetacognition("TecX", "Alta Igreja", "perigoso", meta);
+
+        Assert.Contains("TecX", meta.ForbiddenKnowledge);
+        Assert.True(KnowledgePersecution.IsForbidden("TecX"));
+    }
+}


### PR DESCRIPTION
## Summary
- support forging historical treaties and rewriting events
- track forbidden knowledge inside `MetacognitionSystem`
- integrate persecution of knowledge with metacognitive tracking
- add unit tests for the new systems

## Testing
- `dotnet build tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684437057e7883239da2939ef9b6c3aa