### PR TITLE
Add cultural cipher books and doctrine conflicts

### DIFF
--- a/src/UltraWorldAI/Communication/CulturalCipherBookSystem.cs
+++ b/src/UltraWorldAI/Communication/CulturalCipherBookSystem.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Communication;
+
+public class SecretBook
+{
+    public string Title { get; set; } = string.Empty;
+    public string Culture { get; set; } = string.Empty;
+    public Dictionary<string, string> Vocabulary { get; set; } = new();
+    public string EncodedText { get; set; } = string.Empty;
+}
+
+public static class CulturalCipherBookSystem
+{
+    public static List<SecretBook> Books { get; } = new();
+
+    public static void AddBook(string title, string culture, Dictionary<string, string> vocab, string text)
+    {
+        var words = text.Split(' ');
+        for (var i = 0; i < words.Length; i++)
+        {
+            if (vocab.ContainsKey(words[i]))
+                words[i] = vocab[words[i]];
+        }
+
+        Books.Add(new SecretBook
+        {
+            Title = title,
+            Culture = culture,
+            Vocabulary = vocab,
+            EncodedText = string.Join(" ", words)
+        });
+
+        Console.WriteLine($"\uD83D\uDCD6 Livro secreto criado: {title} | Cultura: {culture}");
+    }
+
+    public static string? ReadBook(string title, string culture)
+    {
+        var book = Books.Find(b => b.Title == title);
+        if (book == null) return null;
+
+        if (book.Culture != culture)
+        {
+            Console.WriteLine($"\u274C {culture} n\u00e3o consegue decifrar o livro '{title}'.");
+            return null;
+        }
+
+        var decoded = Decode(book.EncodedText, book.Vocabulary);
+        Console.WriteLine($"\uD83D\uDCDA Conte\u00fado decifrado de '{title}': {decoded}");
+        return decoded;
+    }
+
+    private static string Decode(string text, Dictionary<string, string> vocab)
+    {
+        var reverse = new Dictionary<string, string>();
+        foreach (var kv in vocab)
+            reverse[kv.Value] = kv.Key;
+
+        var words = text.Split(' ');
+        for (var i = 0; i < words.Length; i++)
+        {
+            if (reverse.ContainsKey(words[i]))
+                words[i] = reverse[words[i]];
+        }
+
+        return string.Join(" ", words);
+    }
+}

--- a/src/UltraWorldAI/Doctrine/DoctrineNarrativeConflictSystem.cs
+++ b/src/UltraWorldAI/Doctrine/DoctrineNarrativeConflictSystem.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Doctrine;
+
+public class DoctrineNarrativeConflict
+{
+    public string Kingdom { get; set; } = string.Empty;
+    public string OfficialDoctrine { get; set; } = string.Empty;
+    public string PopularVersion { get; set; } = string.Empty;
+    public int PopularSupport { get; set; }
+    public bool RegimeChanged { get; set; }
+}
+
+public static class DoctrineNarrativeConflictSystem
+{
+    public static List<DoctrineNarrativeConflict> Conflicts { get; } = new();
+
+    public static void AddConflict(string kingdom, string official, string popular, int support)
+    {
+        Conflicts.Add(new DoctrineNarrativeConflict
+        {
+            Kingdom = kingdom,
+            OfficialDoctrine = official,
+            PopularVersion = popular,
+            PopularSupport = support,
+            RegimeChanged = false
+        });
+
+        Console.WriteLine($"\uD83D\uDD04 Conflito doutrin\u00e1rio iniciado em {kingdom} (apoio popular: {support}% )");
+    }
+
+    public static void Escalate(string kingdom, int change)
+    {
+        var conflict = Conflicts.Find(c => c.Kingdom == kingdom);
+        if (conflict == null) return;
+
+        conflict.PopularSupport += change;
+        if (conflict.PopularSupport >= 70 && !conflict.RegimeChanged)
+        {
+            conflict.RegimeChanged = true;
+            Console.WriteLine($"\uD83C\uDFDB\uFE0F O reino {kingdom} mudou de regime devido \u00e0 press\u00e3o popular!");
+        }
+    }
+
+    public static void PrintConflicts()
+    {
+        foreach (var c in Conflicts)
+        {
+            Console.WriteLine($"\n\uD83D\uDD04 {c.Kingdom} | Doutrina: {c.OfficialDoctrine} | Vers\u00e3o popular: {c.PopularVersion} | Apoio: {c.PopularSupport}% | Mudou? {c.RegimeChanged}");
+        }
+    }
+}

--- a/src/UltraWorldAI/History/RegionalHistoryBeliefSystem.cs
+++ b/src/UltraWorldAI/History/RegionalHistoryBeliefSystem.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.History;
+
+public static class RegionalHistoryBeliefSystem
+{
+    private static readonly Dictionary<Person, string> Birthplaces = new();
+    private static readonly Dictionary<string, string> OfficialVersions = new();
+    private static readonly Dictionary<string, Dictionary<string, string>> RegionalVersions = new();
+
+    public static void RegisterBirthPlace(Person person, string region)
+    {
+        Birthplaces[person] = region;
+    }
+
+    public static void AddEvent(string eventName, string officialVersion)
+    {
+        OfficialVersions[eventName] = officialVersion;
+    }
+
+    public static void AddRegionalVersion(string eventName, string region, string version)
+    {
+        if (!RegionalVersions.ContainsKey(eventName))
+            RegionalVersions[eventName] = new();
+
+        RegionalVersions[eventName][region] = version;
+    }
+
+    public static string Teach(Person person, string eventName)
+    {
+        var region = Birthplaces.TryGetValue(person, out var r) ? r : "unknown";
+        var version = OfficialVersions.TryGetValue(eventName, out var off) ? off : "desconhecido";
+
+        if (RegionalVersions.ContainsKey(eventName) && RegionalVersions[eventName].TryGetValue(region, out var alt))
+            version = alt;
+
+        person.Mind.Memory.AddMemory($"Aprendeu sobre {eventName}: {version}", 0.3f, 0f, new() { "hist\u00f3ria" }, "ensino");
+        return version;
+    }
+}

--- a/tests/UltraWorldAI.Tests/CulturalCipherBookSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CulturalCipherBookSystemTests.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using UltraWorldAI.Communication;
+using Xunit;
+
+public class CulturalCipherBookSystemTests
+{
+    [Fact]
+    public void ReadBookReturnsDecodedForCorrectCulture()
+    {
+        CulturalCipherBookSystem.Books.Clear();
+        var vocab = new Dictionary<string, string>
+        {
+            ["paz"] = "thakar",
+            ["alian\u00e7a"] = "morn"
+        };
+
+        CulturalCipherBookSystem.AddBook("Codex", "Solarianos", vocab, "paz alian\u00e7a");
+        var decoded = CulturalCipherBookSystem.ReadBook("Codex", "Solarianos");
+
+        Assert.Equal("paz alian\u00e7a", decoded);
+    }
+}

--- a/tests/UltraWorldAI.Tests/DoctrineNarrativeConflictSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DoctrineNarrativeConflictSystemTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Doctrine;
+using Xunit;
+
+public class DoctrineNarrativeConflictSystemTests
+{
+    [Fact]
+    public void EscalateChangesRegimeWhenSupportHigh()
+    {
+        DoctrineNarrativeConflictSystem.Conflicts.Clear();
+        DoctrineNarrativeConflictSystem.AddConflict("Reino", "Oficial", "Popular", 60);
+        DoctrineNarrativeConflictSystem.Escalate("Reino", 15);
+
+        Assert.True(DoctrineNarrativeConflictSystem.Conflicts[0].RegimeChanged);
+    }
+}

--- a/tests/UltraWorldAI.Tests/RegionalHistoryBeliefSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/RegionalHistoryBeliefSystemTests.cs
@@ -1,0 +1,18 @@
+using UltraWorldAI;
+using UltraWorldAI.History;
+using Xunit;
+
+public class RegionalHistoryBeliefSystemTests
+{
+    [Fact]
+    public void TeachReturnsRegionalVersion()
+    {
+        var person = new Person("Historian");
+        RegionalHistoryBeliefSystem.RegisterBirthPlace(person, "Norte");
+        RegionalHistoryBeliefSystem.AddEvent("Batalha", "O rei venceu");
+        RegionalHistoryBeliefSystem.AddRegionalVersion("Batalha", "Norte", "O povo rebelde triunfou");
+
+        var result = RegionalHistoryBeliefSystem.Teach(person, "Batalha");
+        Assert.Equal("O povo rebelde triunfou", result);
+    }
+}


### PR DESCRIPTION
## Summary
- implement CulturalCipherBookSystem for encoded books
- implement RegionalHistoryBeliefSystem to teach alternative histories
- implement DoctrineNarrativeConflictSystem to track regime shifts
- add unit tests for the new systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v m`

------
https://chatgpt.com/codex/tasks/task_e_68443fe92dc08323869c93ca64616f55