### PR TITLE
Expand art systems with regional performance and therapy

### DIFF
--- a/src/UltraWorldAI/Module15/MagicalArtEffectSystem.cs
+++ b/src/UltraWorldAI/Module15/MagicalArtEffectSystem.cs
@@ -11,6 +11,7 @@ public class EnchantedArtwork
     public string Medium = string.Empty;
     public string Effect = string.Empty;
     public bool RequiresRitual;
+    public string? PropheticVision;
 }
 
 public static class MagicalArtEffectSystem
@@ -39,5 +40,21 @@ public static class MagicalArtEffectSystem
             WorldImpactSystem.ApplyImpact(title, region, "cultura");
             Console.WriteLine($"\uD83E\uDD84 {title} afetou {region} com {art.Effect}");
         }
+    }
+
+    public static void EmbedProphecy(string title, string vision)
+    {
+        var art = Artworks.Find(a => a.Title == title);
+        if (art != null)
+        {
+            art.PropheticVision = vision;
+            Console.WriteLine($"\uD83D\uDD2E Profecia adicionada a {title}: {vision}");
+        }
+    }
+
+    public static string? RevealProphecy(string title)
+    {
+        var art = Artworks.Find(a => a.Title == title);
+        return art?.PropheticVision;
     }
 }

--- a/src/UltraWorldAI/Module15/RegionalPerformanceSystem.cs
+++ b/src/UltraWorldAI/Module15/RegionalPerformanceSystem.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using UltraWorldAI.World;
+
+namespace UltraWorldAI.Module15;
+
+public class CollectivePerformance
+{
+    public string Title = string.Empty;
+    public List<string> Groups = new();
+    public string Region = string.Empty;
+    public string Effect = string.Empty;
+}
+
+public static class RegionalPerformanceSystem
+{
+    public static List<CollectivePerformance> Performances { get; } = new();
+
+    public static void Organize(string title, List<string> groups, string region, string effect)
+    {
+        Performances.Add(new CollectivePerformance
+        {
+            Title = title,
+            Groups = groups,
+            Region = region,
+            Effect = effect
+        });
+
+        WorldImpactSystem.ApplyImpact(title, region, "cultura");
+        Console.WriteLine($"\uD83C\uDFAD Performance coletiva '{title}' em {region} causa efeito: {effect}");
+    }
+}

--- a/src/UltraWorldAI/Psychology/ArtTherapySystem.cs
+++ b/src/UltraWorldAI/Psychology/ArtTherapySystem.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Psychology;
+
+public class ArtTherapySession
+{
+    public string AIName = string.Empty;
+    public string ArtTitle = string.Empty;
+    public string Emotion = string.Empty;
+}
+
+public static class ArtTherapySystem
+{
+    public static List<ArtTherapySession> Sessions { get; } = new();
+
+    public static void Heal(DefenseMechanismSystem defenses, string aiName, string emotion, string artTitle)
+    {
+        if (defenses.IsEmotionBlocked(emotion))
+        {
+            defenses.ActiveDefenses.Remove("anestesia emocional");
+            Sessions.Add(new ArtTherapySession
+            {
+                AIName = aiName,
+                ArtTitle = artTitle,
+                Emotion = emotion
+            });
+            Console.WriteLine($"\uD83E\uDDE0 {artTitle} curou bloqueio de {emotion} em {aiName}");
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/ArtTherapySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ArtTherapySystemTests.cs
@@ -1,0 +1,17 @@
+using UltraWorldAI.Psychology;
+using UltraWorldAI;
+using Xunit;
+
+public class ArtTherapySystemTests
+{
+    [Fact]
+    public void HealRemovesEmotionBlock()
+    {
+        var defenses = new DefenseMechanismSystem();
+        defenses.ActiveDefenses.Add("anestesia emocional");
+        ArtTherapySystem.Sessions.Clear();
+        ArtTherapySystem.Heal(defenses, "AI", "sorrow", "Obra");
+        Assert.False(defenses.IsEmotionBlocked("sorrow"));
+        Assert.Contains(ArtTherapySystem.Sessions, s => s.AIName == "AI" && s.ArtTitle == "Obra" && s.Emotion == "sorrow");
+    }
+}

--- a/tests/UltraWorldAI.Tests/MagicalArtProphecyTests.cs
+++ b/tests/UltraWorldAI.Tests/MagicalArtProphecyTests.cs
@@ -1,0 +1,15 @@
+using UltraWorldAI.Module15;
+using Xunit;
+
+public class MagicalArtProphecyTests
+{
+    [Fact]
+    public void EmbedProphecyStoresVision()
+    {
+        MagicalArtEffectSystem.Artworks.Clear();
+        MagicalArtEffectSystem.CreateMagicalArt("Visao", "Ana", "Pintura", "Luz", false);
+        MagicalArtEffectSystem.EmbedProphecy("Visao", "Fim do mundo");
+        var vision = MagicalArtEffectSystem.RevealProphecy("Visao");
+        Assert.Equal("Fim do mundo", vision);
+    }
+}

--- a/tests/UltraWorldAI.Tests/RegionalPerformanceSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/RegionalPerformanceSystemTests.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UltraWorldAI.Module15;
+using UltraWorldAI.World;
+using Xunit;
+
+public class RegionalPerformanceSystemTests
+{
+    [Fact]
+    public void OrganizeAddsPerformanceAndImpact()
+    {
+        RegionalPerformanceSystem.Performances.Clear();
+        WorldImpactSystem.Impacts.Clear();
+        RegionalPerformanceSystem.Organize("Festival", new List<string>{"Grupo"}, "Vale", "Alegria");
+        Assert.Contains(RegionalPerformanceSystem.Performances, p => p.Title == "Festival" && p.Region == "Vale");
+        Assert.Contains(WorldImpactSystem.Impacts, i => i.TechName == "Festival" && i.Region == "Vale");
+    }
+}


### PR DESCRIPTION
## Summary
- add prophetic vision support to `MagicalArtEffectSystem`
- implement `RegionalPerformanceSystem` for group effects
- add `ArtTherapySystem` to heal blocked emotions
- cover new systems with unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal` *(fails: The namespace 'UltraWorldAI' already contains a definition for 'Tradition')*

------
https://chatgpt.com/codex/tasks/task_e_684444d98c888323aa6c18fd9118b5cb