### PR TITLE
Add mental noise sorcery and cult systems

### DIFF
--- a/src/UltraWorldAI/Module16/CognitiveOverloadSystem.cs
+++ b/src/UltraWorldAI/Module16/CognitiveOverloadSystem.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module16;
+
+public enum MentalState { Normal, Perturbado, Extatico, Insano }
+
+public class CognitiveReaction
+{
+    public string AI = string.Empty;
+    public string Region = string.Empty;
+    public float NoiseLevel;
+    public MentalState State;
+}
+
+public static class CognitiveOverloadSystem
+{
+    public static List<CognitiveReaction> Reactions { get; } = new();
+
+    public static MentalState EvaluateState(float noise)
+    {
+        if (noise < 5) return MentalState.Normal;
+        if (noise < 15) return MentalState.Perturbado;
+        if (noise < 25) return MentalState.Extatico;
+        return MentalState.Insano;
+    }
+
+    public static void ReactToNoise(string ai, string region)
+    {
+        float noise = MentalNoiseSystem.GetNoiseLevel(region);
+        var state = EvaluateState(noise);
+
+        Reactions.Add(new CognitiveReaction
+        {
+            AI = ai,
+            Region = region,
+            NoiseLevel = noise,
+            State = state
+        });
+
+        Console.WriteLine($"\uD83E\uDEE8 {ai} est\u00e1 agora em estado mental: {state} (Ru\u00eddo: {noise:0.00})");
+    }
+}

--- a/src/UltraWorldAI/Module16/CollectiveEntitySystem.cs
+++ b/src/UltraWorldAI/Module16/CollectiveEntitySystem.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module16;
+
+public class ThoughtEntity
+{
+    public string Name = string.Empty;
+    public string CoreEmotion = string.Empty; // "Culpa", "Desejo", "Memoria", "Raiva"
+    public string Region = string.Empty;
+    public float InfluenceLevel; // 0-1
+    public bool ManifestedPhysically;
+}
+
+public static class CollectiveEntitySystem
+{
+    public static List<ThoughtEntity> Entities { get; } = new();
+
+    public static void TrySpawnEntity(string region)
+    {
+        float noise = MentalNoiseSystem.GetNoiseLevel(region);
+        if (noise < 10f) return;
+
+        string dominantEmotion = MentalNoiseSystem.ThoughtStream
+            .FindLast(p => p.Region == region)?.ThoughtTag ?? "Medo";
+
+        var entity = new ThoughtEntity
+        {
+            Name = $"Eco de {dominantEmotion}",
+            CoreEmotion = dominantEmotion,
+            Region = region,
+            InfluenceLevel = Math.Min(noise / 100f, 1f),
+            ManifestedPhysically = noise > 30f
+        };
+
+        Entities.Add(entity);
+        Console.WriteLine($"\uD83D\uDC41\uFE0F ENTIDADE NASCEU: {entity.Name} em {region} | Emo\u00e7\u00e3o: {entity.CoreEmotion} | F\u00edsico? {entity.ManifestedPhysically}");
+    }
+}

--- a/src/UltraWorldAI/Module16/MentalEpidemicSystem.cs
+++ b/src/UltraWorldAI/Module16/MentalEpidemicSystem.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module16;
+
+public enum EpidemicType { MassSuicide, InsaneArt, MentalPlague }
+
+public class EpidemicEvent
+{
+    public string Region = string.Empty;
+    public EpidemicType Type;
+    public DateTime Timestamp;
+}
+
+public static class MentalEpidemicSystem
+{
+    public static List<EpidemicEvent> Events { get; } = new();
+
+    public static void EvaluateRegion(string region)
+    {
+        float noise = MentalNoiseSystem.GetNoiseLevel(region);
+        if (noise < 35f) return;
+
+        var type = noise > 50f ? EpidemicType.MassSuicide : noise > 40f ? EpidemicType.InsaneArt : EpidemicType.MentalPlague;
+        Events.Add(new EpidemicEvent { Region = region, Type = type, Timestamp = DateTime.Now });
+        Console.WriteLine($"\uD83D\uDD25 Epidemia {type} detectada em {region} (Ru\u00eddo {noise:0.00})");
+    }
+}

--- a/src/UltraWorldAI/Module16/MentalNoiseSystem.cs
+++ b/src/UltraWorldAI/Module16/MentalNoiseSystem.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Module16;
+
+public class ThoughtPulse
+{
+    public string SourceAI = string.Empty;
+    public string ThoughtTag = string.Empty; // "Medo", "Culpa", "Esperanca", "Solidao", "Revolta"
+    public float EmotionalWeight;
+    public string Region = string.Empty;
+    public DateTime Timestamp;
+}
+
+public static class MentalNoiseSystem
+{
+    public static List<ThoughtPulse> ThoughtStream { get; } = new();
+
+    public static void EmitThought(string ai, string tag, float weight, string region)
+    {
+        ThoughtStream.Add(new ThoughtPulse
+        {
+            SourceAI = ai,
+            ThoughtTag = tag,
+            EmotionalWeight = weight,
+            Region = region,
+            Timestamp = DateTime.Now
+        });
+
+        Console.WriteLine($"\uD83C\uDF00 {ai} gerou pensamento '{tag}' com peso {weight:0.00} em {region}");
+    }
+
+    public static float GetNoiseLevel(string region)
+    {
+        var recent = ThoughtStream
+            .Where(p => p.Region == region && (DateTime.Now - p.Timestamp).TotalHours <= 12)
+            .Sum(p => p.EmotionalWeight);
+
+        return recent;
+    }
+}

--- a/src/UltraWorldAI/Module16/NoiseSorcerySystem.cs
+++ b/src/UltraWorldAI/Module16/NoiseSorcerySystem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Module16;
+
+public class NoiseSpell
+{
+    public string Caster = string.Empty;
+    public string Region = string.Empty;
+    public float Power;
+    public string Effect = string.Empty;
+    public DateTime Timestamp;
+}
+
+public static class NoiseSorcerySystem
+{
+    public static List<NoiseSpell> Spells { get; } = new();
+
+    public static void ChannelNoise(string caster, string region)
+    {
+        float noise = MentalNoiseSystem.GetNoiseLevel(region);
+        if (noise <= 0f) return;
+
+        var spell = new NoiseSpell
+        {
+            Caster = caster,
+            Region = region,
+            Power = noise,
+            Effect = noise > 20f ? "Explosao de Caos" : "Ondas Psiquicas",
+            Timestamp = DateTime.Now
+        };
+
+        Spells.Add(spell);
+        Console.WriteLine($"\uD83E\uDEA5 {caster} canaliza ru\u00eddo {noise:0.00} em {region} gerando {spell.Effect}");
+    }
+}

--- a/src/UltraWorldAI/Module16/PsychicCultSystem.cs
+++ b/src/UltraWorldAI/Module16/PsychicCultSystem.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Module16;
+
+public class PsychicCult
+{
+    public string Name = string.Empty;
+    public string Entity = string.Empty;
+    public List<string> Members = new();
+    public float DevotionLevel;
+}
+
+public static class PsychicCultSystem
+{
+    public static List<PsychicCult> Cults { get; } = new();
+
+    public static void CreateCult(string name, string entity)
+    {
+        Cults.Add(new PsychicCult { Name = name, Entity = entity, DevotionLevel = 0.5f });
+        Console.WriteLine($"\uD83C\uDF0D Culto '{name}' fundado em torno de {entity}");
+    }
+
+    public static void RecruitMember(string cultName, string member)
+    {
+        var cult = Cults.FirstOrDefault(c => c.Name == cultName);
+        if (cult == null) return;
+        cult.Members.Add(member);
+        cult.DevotionLevel = Math.Min(1f, cult.DevotionLevel + 0.05f);
+        Console.WriteLine($"\uD83D\uDD2C {member} ingressou no culto {cultName}");
+    }
+}

--- a/tests/UltraWorldAI.Tests/MentalNoiseSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/MentalNoiseSystemTests.cs
@@ -1,0 +1,34 @@
+using UltraWorldAI.Module16;
+using Xunit;
+
+public class MentalNoiseSystemTests
+{
+    [Fact]
+    public void EmitThoughtAddsPulse()
+    {
+        MentalNoiseSystem.ThoughtStream.Clear();
+        MentalNoiseSystem.EmitThought("Elira", "Culpa", 3.5f, "Templo");
+        Assert.Contains(MentalNoiseSystem.ThoughtStream, p => p.SourceAI == "Elira");
+    }
+
+    [Fact]
+    public void TrySpawnEntityCreatesEntity()
+    {
+        MentalNoiseSystem.ThoughtStream.Clear();
+        CollectiveEntitySystem.Entities.Clear();
+        MentalNoiseSystem.EmitThought("Elira", "Medo", 6f, "Ruinas");
+        MentalNoiseSystem.EmitThought("Kael", "Medo", 5f, "Ruinas");
+        CollectiveEntitySystem.TrySpawnEntity("Ruinas");
+        Assert.NotEmpty(CollectiveEntitySystem.Entities);
+    }
+
+    [Fact]
+    public void ReactToNoiseStoresReaction()
+    {
+        MentalNoiseSystem.ThoughtStream.Clear();
+        CognitiveOverloadSystem.Reactions.Clear();
+        MentalNoiseSystem.EmitThought("Sarel", "Raiva", 7f, "Praia");
+        CognitiveOverloadSystem.ReactToNoise("Sarel", "Praia");
+        Assert.Contains(CognitiveOverloadSystem.Reactions, r => r.AI == "Sarel");
+    }
+}


### PR DESCRIPTION
## Summary
- implement new Module16 with MentalNoiseSystem, CollectiveEntitySystem, and CognitiveOverloadSystem
- add NoiseSorcerySystem, PsychicCultSystem, and MentalEpidemicSystem to expand features
- create tests covering basic functionality of the mental noise systems

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68444a2520d88323aadc91fc21a37192