### PR TITLE
Integrate psychic magic and cult features

### DIFF
--- a/src/UltraWorldAI/Magic/PsychicMagicSystem.cs
+++ b/src/UltraWorldAI/Magic/PsychicMagicSystem.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UltraWorldAI.Module16;
+
+namespace UltraWorldAI.Magic;
+
+public class PsychicChanneler
+{
+    public string Name = string.Empty;
+    public string Region = string.Empty;
+    public float StoredPower;
+    public string Style = string.Empty; // "Alucinação", "Visão", "Grito Mental", "Maré Psíquica"
+}
+
+public static class PsychicMagicSystem
+{
+    public static List<PsychicChanneler> Channelers { get; } = new();
+
+    public static void ChannelNoise(string ai, string region, string style)
+    {
+        float noise = MentalNoiseSystem.GetNoiseLevel(region);
+        if (noise < 8f) return;
+
+        var existing = Channelers.FirstOrDefault(c => c.Name == ai && c.Region == region);
+        if (existing == null)
+        {
+            existing = new PsychicChanneler { Name = ai, Region = region, Style = style };
+            Channelers.Add(existing);
+        }
+
+        existing.Style = style;
+        existing.StoredPower += noise / 2f;
+        Console.WriteLine($"\uD83E\uDDD9\u200D♂️ {ai} canalizou {noise:0.0} de ru\u00EDdo em {region} acumulando {existing.StoredPower:0.0} ({style})");
+    }
+
+    public static void CastMentalSpell(string ai, string spell)
+    {
+        var chan = Channelers.FirstOrDefault(x => x.Name == ai);
+        if (chan == null || chan.StoredPower < 5f)
+        {
+            Console.WriteLine($"\u26A0\uFE0F {ai} tentou lan\u00E7ar {spell}, mas n\u00E3o tinha poder ps\u00EDquico suficiente.");
+            return;
+        }
+
+        chan.StoredPower -= 5f;
+        Console.WriteLine($"\u2728 {ai} lan\u00E7ou o feiti\u00E7o ps\u00EDquico '{spell}' usando {chan.Style}. Poder restante: {chan.StoredPower:0.0}");
+    }
+}

--- a/src/UltraWorldAI/Religion/PsychicCultSystem.cs
+++ b/src/UltraWorldAI/Religion/PsychicCultSystem.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UltraWorldAI.Religion;
+
+public class PsychicCult
+{
+    public string Name = string.Empty;
+    public string WorshipedEntity = string.Empty;
+    public List<string> Followers { get; } = new();
+    public string Doctrine = string.Empty; // "Silêncio Mental", "Expansão da Dor", "Iluminação do Vazio"
+}
+
+public static class PsychicCultSystem
+{
+    public static List<PsychicCult> Cults { get; } = new();
+
+    public static PsychicCult CreateCult(string entity, string doctrine)
+    {
+        var cult = new PsychicCult
+        {
+            Name = $"Ordem de {entity}",
+            WorshipedEntity = entity,
+            Doctrine = doctrine
+        };
+
+        Cults.Add(cult);
+        Console.WriteLine($"\u26EA Culto criado: {cult.Name} | Doutrina: {doctrine}");
+        return cult;
+    }
+
+    public static void JoinCult(string ai, string entity)
+    {
+        var cult = Cults.FirstOrDefault(c => c.WorshipedEntity == entity);
+        if (cult != null && !cult.Followers.Contains(ai))
+        {
+            cult.Followers.Add(ai);
+            Console.WriteLine($"\uD83D\uDE4F {ai} juntou-se à {cult.Name}");
+        }
+    }
+
+    public static void LeaveCult(string ai, string entity)
+    {
+        var cult = Cults.FirstOrDefault(c => c.WorshipedEntity == entity);
+        if (cult != null && cult.Followers.Remove(ai))
+        {
+            Console.WriteLine($"\uD83D\uDC4B {ai} deixou a {cult.Name}");
+        }
+    }
+
+    public static string DescribeCult(string entity)
+    {
+        var cult = Cults.FirstOrDefault(c => c.WorshipedEntity == entity);
+        if (cult == null) return "Culto não encontrado.";
+
+        return $"\u26EA {cult.Name} | Doutrina: {cult.Doctrine} | Seguidores: {cult.Followers.Count}";
+    }
+}

--- a/tests/UltraWorldAI.Tests/PsychicCultSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PsychicCultSystemTests.cs
@@ -1,0 +1,29 @@
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class PsychicCultSystemTests
+{
+    [Fact]
+    public void CreateCultAddsCult()
+    {
+        PsychicCultSystem.Cults.Clear();
+        var cult = PsychicCultSystem.CreateCult("Eco", "Iluminação do Vazio");
+
+        Assert.Single(PsychicCultSystem.Cults);
+        Assert.Equal("Ordem de Eco", cult.Name);
+        PsychicCultSystem.Cults.Clear();
+    }
+
+    [Fact]
+    public void JoinAndLeaveCultUpdatesFollowers()
+    {
+        PsychicCultSystem.Cults.Clear();
+        PsychicCultSystem.CreateCult("Eco", "Silêncio Mental");
+        PsychicCultSystem.JoinCult("Thalor", "Eco");
+        PsychicCultSystem.LeaveCult("Thalor", "Eco");
+
+        var cult = PsychicCultSystem.Cults[0];
+        Assert.Empty(cult.Followers);
+        PsychicCultSystem.Cults.Clear();
+    }
+}

--- a/tests/UltraWorldAI.Tests/PsychicMagicSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PsychicMagicSystemTests.cs
@@ -1,0 +1,31 @@
+using UltraWorldAI.Magic;
+using UltraWorldAI.Module16;
+using Xunit;
+
+public class PsychicMagicSystemTests
+{
+    [Fact]
+    public void ChannelNoiseAddsChanneler()
+    {
+        PsychicMagicSystem.Channelers.Clear();
+        MentalNoiseSystem.ThoughtStream.Clear();
+        MentalNoiseSystem.EmitThought("Elira", "Culpa", 10f, "Cidade");
+
+        PsychicMagicSystem.ChannelNoise("Elira", "Cidade", "Visão Ressonante");
+
+        Assert.Contains(PsychicMagicSystem.Channelers, c => c.Name == "Elira");
+        MentalNoiseSystem.ThoughtStream.Clear();
+    }
+
+    [Fact]
+    public void CastMentalSpellConsumesPower()
+    {
+        PsychicMagicSystem.Channelers.Clear();
+        var chan = new PsychicChanneler { Name = "Elira", Region = "Cidade", StoredPower = 10f, Style = "Visão" };
+        PsychicMagicSystem.Channelers.Add(chan);
+
+        PsychicMagicSystem.CastMentalSpell("Elira", "Explosão");
+
+        Assert.Equal(5f, chan.StoredPower);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `PsychicMagicSystem` for channeling mental noise
- add new `PsychicCultSystem` for cult management
- test psychic magic and cult behaviour

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68444f56f80c832392da2d0bf9f02a92