### PR TITLE
Add divine world creation modules

### DIFF
--- a/src/UltraWorldAI/DivineWorld/CosmologyCreationSystem.cs
+++ b/src/UltraWorldAI/DivineWorld/CosmologyCreationSystem.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.DivineWorld;
+
+public class DivineEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public string Domain { get; set; } = string.Empty;
+    public string Memory { get; set; } = string.Empty;
+}
+
+public class AlternatePlane
+{
+    public string Name { get; set; } = string.Empty;
+    public string Nature { get; set; } = string.Empty;
+    public List<string> Laws { get; set; } = new();
+}
+
+public static class CosmologyCreationSystem
+{
+    public static List<DivineEntity> Entities { get; } = new();
+    public static List<AlternatePlane> Planes { get; } = new();
+
+    public static void CreateEntity(string name, string role, string domain, string memory)
+    {
+        Entities.Add(new DivineEntity
+        {
+            Name = name,
+            Role = role,
+            Domain = domain,
+            Memory = memory
+        });
+        Console.WriteLine($"\u272F Nova entidade criada: {name}, dom\u00ednio: {domain}, papel: {role}");
+    }
+
+    public static void CreatePlane(string name, string nature, List<string> laws)
+    {
+        Planes.Add(new AlternatePlane
+        {
+            Name = name,
+            Nature = nature,
+            Laws = laws
+        });
+        Console.WriteLine($"\uD83C\uDF0C Plano alternativo criado: {name} ({nature}) com leis: {string.Join(", ", laws)}");
+    }
+}
+

--- a/src/UltraWorldAI/DivineWorld/DivineWillSystem.cs
+++ b/src/UltraWorldAI/DivineWorld/DivineWillSystem.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.DivineWorld;
+
+public enum DivinePersonality
+{
+    Compassionate,
+    Chaotic,
+    Vengeful,
+    Silent,
+    Creator
+}
+
+public class DivineAction
+{
+    public string Target { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty; // "Miracle", "Punishment", etc
+    public string Description { get; set; } = string.Empty;
+}
+
+public static class DivineWillSystem
+{
+    public static DivinePersonality Personality { get; private set; } = DivinePersonality.Creator;
+    public static List<DivineAction> Interventions { get; } = new();
+
+    public static void Intervene(string target, string type, string description)
+    {
+        var action = new DivineAction
+        {
+            Target = target,
+            Type = type,
+            Description = description
+        };
+
+        Interventions.Add(action);
+        Console.WriteLine($"\u26A1 Interven\u00e7\u00e3o divina: {type} em {target} → {description}");
+    }
+
+    public static void SetPersonality(DivinePersonality personality)
+    {
+        Personality = personality;
+        Console.WriteLine($"\u2728 Personalidade divina definida: {personality}");
+    }
+}
+

--- a/src/UltraWorldAI/DivineWorld/WorldShapingSystem.cs
+++ b/src/UltraWorldAI/DivineWorld/WorldShapingSystem.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.DivineWorld;
+
+public static class WorldShapingSystem
+{
+    public static List<string> CreatedElements { get; } = new();
+
+    public static void CreateGeography(string elementType, string name)
+    {
+        CreatedElements.Add($"{elementType}: {name}");
+        Console.WriteLine($"\uD83D\uDDFA\uFE0F Geografia criada: {elementType} – {name}");
+    }
+
+    public static void CreateRace(string name, string traits, string language)
+    {
+        Console.WriteLine($"\uD83E\uDDEC Ra\u00e7a criada: {name} | Tra\u00e7os: {traits} | L\u00edngua: {language}");
+    }
+
+    public static void DefineLaw(string lawType, string description)
+    {
+        Console.WriteLine($"\uD83D\uDCDC Lei divina estabelecida: {lawType} → {description}");
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/CosmologyCreationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/CosmologyCreationSystemTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using UltraWorldAI.DivineWorld;
+using Xunit;
+
+public class CosmologyCreationSystemTests
+{
+    [Fact]
+    public void CreateEntityAddsToList()
+    {
+        CosmologyCreationSystem.Entities.Clear();
+        CosmologyCreationSystem.CreateEntity("Nyara", "Guardi\u00e3o", "Sonhos", "Mem\u00f3ria");
+        Assert.Single(CosmologyCreationSystem.Entities);
+        Assert.Equal("Nyara", CosmologyCreationSystem.Entities[0].Name);
+    }
+
+    [Fact]
+    public void CreatePlaneRegistersPlane()
+    {
+        CosmologyCreationSystem.Planes.Clear();
+        CosmologyCreationSystem.CreatePlane("N\u00e9voa", "On\u00edrico", new List<string> { "Tempo" });
+        Assert.Single(CosmologyCreationSystem.Planes);
+        Assert.Equal("N\u00e9voa", CosmologyCreationSystem.Planes[0].Name);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/DivineWillSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DivineWillSystemTests.cs
@@ -1,0 +1,22 @@
+using UltraWorldAI.DivineWorld;
+using Xunit;
+
+public class DivineWillSystemTests
+{
+    [Fact]
+    public void InterveneAddsAction()
+    {
+        DivineWillSystem.Interventions.Clear();
+        DivineWillSystem.Intervene("Cidade", "Milagre", "Chuva de estrelas");
+        Assert.Single(DivineWillSystem.Interventions);
+        Assert.Equal("Cidade", DivineWillSystem.Interventions[0].Target);
+    }
+
+    [Fact]
+    public void SetPersonalityChangesState()
+    {
+        DivineWillSystem.SetPersonality(DivinePersonality.Chaotic);
+        Assert.Equal(DivinePersonality.Chaotic, DivineWillSystem.Personality);
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/WorldShapingSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/WorldShapingSystemTests.cs
@@ -1,0 +1,14 @@
+using UltraWorldAI.DivineWorld;
+using Xunit;
+
+public class WorldShapingSystemTests
+{
+    [Fact]
+    public void CreateGeographyRegistersElement()
+    {
+        WorldShapingSystem.CreatedElements.Clear();
+        WorldShapingSystem.CreateGeography("Montanha", "Torre Infinita");
+        Assert.Contains("Montanha: Torre Infinita", WorldShapingSystem.CreatedElements);
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `DivineWillSystem` for divine personalities and interventions
- add `CosmologyCreationSystem` to create entities and planes
- implement `WorldShapingSystem` to create geography, races and laws
- cover the new systems with unit tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --logger "console;verbosity=detailed"`

------
https://chatgpt.com/codex/tasks/task_e_6844b9f74d34832397d406504b031e0d