### PR TITLE
Implement divine integration utilities

### DIFF
--- a/src/UltraWorldAI/AIBehavior.cs
+++ b/src/UltraWorldAI/AIBehavior.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI;
+
+public static class AIBehavior
+{
+    public static Dictionary<string, string> AvoidedZones { get; } = new();
+
+    public static void AvoidZone(string zone, string reason)
+    {
+        AvoidedZones[zone] = reason;
+    }
+}

--- a/src/UltraWorldAI/AIPopulation.cs
+++ b/src/UltraWorldAI/AIPopulation.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI;
+
+public static class AIPopulation
+{
+    public static Dictionary<string, List<string>> Behaviors { get; } = new();
+
+    public static void AdaptBehavior(string group, string behavior)
+    {
+        if (!Behaviors.ContainsKey(group))
+            Behaviors[group] = new List<string>();
+        Behaviors[group].Add(behavior);
+    }
+}

--- a/src/UltraWorldAI/CultureSystem.cs
+++ b/src/UltraWorldAI/CultureSystem.cs
@@ -17,6 +17,7 @@ namespace UltraWorldAI
         public List<string> AssociatedIdeas { get; set; } = new();
         public Calendar CulturalCalendar { get; set; } = new(CalendarType.Lunar);
         public List<Festival> Festivals { get; set; } = new();
+        public List<string> SacredForms { get; set; } = new();
         /// <summary>
         /// Memories shared collectively by members of the culture.
         /// </summary>
@@ -85,6 +86,26 @@ namespace UltraWorldAI
         {
             var culture = Cultures.FirstOrDefault(c => c.Name == cultureName);
             culture?.CollectiveMemory.AddMemory(summary, intensity, emotionalCharge, keywords, "collective");
+        }
+
+        public void PropagateBelief(string statement, string cultureName)
+        {
+            var culture = Cultures.FirstOrDefault(c => c.Name == cultureName);
+            if (culture == null) return;
+
+            if (!culture.CoreValues.Contains(statement))
+                culture.CoreValues.Add(statement);
+
+            AddCollectiveMemory(cultureName, statement, 0.4f, 0.2f, new() { "crença" });
+        }
+
+        public void DeclareSacredForm(string form)
+        {
+            foreach (var culture in Cultures)
+            {
+                if (!culture.SacredForms.Contains(form))
+                    culture.SacredForms.Add(form);
+            }
         }
 
         private void EvolveCultures(Mind mind)

--- a/src/UltraWorldAI/DivineWorld/DivineIntegrationSystem.cs
+++ b/src/UltraWorldAI/DivineWorld/DivineIntegrationSystem.cs
@@ -1,0 +1,28 @@
+using UltraWorldAI.Religion;
+using UltraWorldAI.World;
+using UltraWorldAI.Time;
+using UltraWorldAI;
+
+namespace UltraWorldAI.DivineWorld;
+
+public static class DivineIntegrationSystem
+{
+    public static void BlessPopulation(
+        DivineBeing god,
+        CultureSystem cultureSystem,
+        PhilosophySystem philosophySystem,
+        string cultureName,
+        string region)
+    {
+        cultureSystem.PropagateBelief($"{god.Name} protege os fi\u00e9is", cultureName);
+        AIPopulation.AdaptBehavior(cultureName, "segue rituais divinos");
+        HistorySystem.LogEvent($"{god.Name} aben\u00e7oou {region}");
+        EraTimelineSystem.AdvanceEpoch($"Era de {god.Name}");
+        ReligionSystem.FoundReligion($"Culto de {god.Name}", $"Adora\u00e7\u00e3o do {god.Domain}", region);
+        philosophySystem.SpreadDoctrine("O vazio \u00e9 divino");
+        WorldMap.AddLandmark($"Templo de {god.Name}", true);
+        AIBehavior.AvoidZone($"Templo de {god.Name}", "Temor ancestral da cria\u00e7\u00e3o divina");
+        cultureSystem.DeclareSacredForm("Simetria Perfeita");
+        MutationSystem.MutateCulture(cultureName, "Bra\u00e7os duplos crescem por devo\u00e7\u00e3o");
+    }
+}

--- a/src/UltraWorldAI/IAWorldLink.cs
+++ b/src/UltraWorldAI/IAWorldLink.cs
@@ -32,6 +32,21 @@ namespace UltraWorldAI
             Events.Add(e);
         }
 
+        public static void LogEvent(string description)
+        {
+            RegisterEvent(new HistoricalEvent
+            {
+                EventName = description,
+                Symbol = description,
+                AffectedCivilizations = new() { "geral" },
+                CulturalImpact = "registro",
+                MemoryState = EventMemoryState.Present,
+                Timestamp = DateTime.Now,
+                OriginEmotion = string.Empty,
+                RecordForm = "texto"
+            });
+        }
+
         public static List<HistoricalEvent> GetEventsForCivilization(string civ)
         {
             return Events.Where(ev => ev.AffectedCivilizations.Contains(civ)).ToList();

--- a/src/UltraWorldAI/MutationSystem.cs
+++ b/src/UltraWorldAI/MutationSystem.cs
@@ -1,0 +1,9 @@
+namespace UltraWorldAI;
+
+public static class MutationSystem
+{
+    public static void MutateCulture(string culture, string description)
+    {
+        CulturalMutationSystem.ApplyMutation(culture, description, "devo\u00e7\u00e3o divina", "Mudan\u00e7a cultural");
+    }
+}

--- a/src/UltraWorldAI/PhilosophySystem.cs
+++ b/src/UltraWorldAI/PhilosophySystem.cs
@@ -26,6 +26,12 @@ namespace UltraWorldAI
             CheckConsistency(brain);
         }
 
+        public void SpreadDoctrine(string doctrine)
+        {
+            if (!Doctrines.Contains(doctrine))
+                Doctrines.Add(doctrine);
+        }
+
         private void CheckConsistency(Mind brain)
         {
             var currentGoal = brain.Goals.ActiveGoals.FirstOrDefault();

--- a/src/UltraWorldAI/Religion/ReligionSystem.cs
+++ b/src/UltraWorldAI/Religion/ReligionSystem.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public class Religion
+{
+    public string Name { get; set; } = string.Empty;
+    public string Doctrine { get; set; } = string.Empty;
+    public string Region { get; set; } = string.Empty;
+}
+
+public static class ReligionSystem
+{
+    public static List<Religion> Religions { get; } = new();
+
+    public static Religion FoundReligion(string name, string doctrine, string region)
+    {
+        var r = new Religion { Name = name, Doctrine = doctrine, Region = region };
+        Religions.Add(r);
+        return r;
+    }
+}

--- a/src/UltraWorldAI/Time/EraTimelineSystem.cs
+++ b/src/UltraWorldAI/Time/EraTimelineSystem.cs
@@ -40,4 +40,9 @@ public static class EraTimelineSystem
         foreach (var e in Eras)
             Console.WriteLine($"\n\ud83d\udcdc {e.Culture} entrou na Era: {e.Name} (Início: {e.StartYear}) | Gatilho: {e.Trigger}");
     }
+
+    public static void AdvanceEpoch(string name)
+    {
+        StartEra("global", name, "evento divino");
+    }
 }

--- a/src/UltraWorldAI/World/WorldMap.cs
+++ b/src/UltraWorldAI/World/WorldMap.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.World;
+
+public static class WorldMap
+{
+    public static List<string> Landmarks { get; } = new();
+
+    public static void AddLandmark(string name, bool isDivine = false)
+    {
+        Landmarks.Add(isDivine ? $"{name} (divino)" : name);
+    }
+}

--- a/tests/UltraWorldAI.Tests/DivineIntegrationSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DivineIntegrationSystemTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using UltraWorldAI;
+using UltraWorldAI.DivineWorld;
+using UltraWorldAI.Religion;
+using UltraWorldAI.World;
+using UltraWorldAI.Time;
+using Xunit;
+
+public class DivineIntegrationSystemTests
+{
+    [Fact]
+    public void BlessPopulationUpdatesModules()
+    {
+        var cultureSystem = new CultureSystem();
+        var philosophy = new PhilosophySystem();
+        var culture = cultureSystem.CreateCultureFromIdea("Teste", new List<string>{"Valor"});
+
+        ReligionSystem.Religions.Clear();
+        WorldMap.Landmarks.Clear();
+        AIBehavior.AvoidedZones.Clear();
+        EraTimelineSystem.Eras.Clear();
+
+        var god = GodFactory.CreateGod("Nyara", DivineDomain.Silencio, DivineTemperament.Dual);
+        DivineIntegrationSystem.BlessPopulation(god, cultureSystem, philosophy, culture.Name, "Zarthis");
+
+        Assert.Contains(culture.CoreValues, v => v.Contains("protege"));
+        Assert.Single(ReligionSystem.Religions);
+        Assert.Contains(WorldMap.Landmarks, l => l.Contains("Nyara"));
+        Assert.Contains($"Templo de {god.Name}", AIBehavior.AvoidedZones.Keys);
+        Assert.NotEmpty(EraTimelineSystem.Eras);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `CultureSystem` with SacredForms and new methods to spread beliefs
- add `LogEvent` to `HistorySystem`
- add `AdvanceEpoch` to `EraTimelineSystem`
- support doctrine spreading in `PhilosophySystem`
- implement new helper modules: `AIPopulation`, `AIBehavior`, `WorldMap`, `MutationSystem`, and `ReligionSystem`
- add `DivineIntegrationSystem` and unit test

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6844bc1de6388323a529ed48c238b0df