### PR TITLE
Add divine interface modules

### DIFF
--- a/src/UltraWorldAI/DivineWorld/DivineReactionSystem.cs
+++ b/src/UltraWorldAI/DivineWorld/DivineReactionSystem.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace UltraWorldAI.DivineWorld;
+
+public static class DivineReactionSystem
+{
+    public static void ReactToSilence(string culture)
+    {
+        var rng = new Random();
+        var roll = rng.Next(0, 100);
+
+        if (roll < 30)
+        {
+            Console.WriteLine($"\uD83D\uDE28 {culture} come\u00e7a a temer o abandono divino \u2192 surgem hereges e cultos apocal\u00edpticos.");
+        }
+        else if (roll < 60)
+        {
+            Console.WriteLine($"\uD83D\uDE4B {culture} interpreta o sil\u00eancio como teste \u2192 nasce uma nova doutrina de paci\u00eancia sagrada.");
+        }
+        else
+        {
+            Console.WriteLine($"\uD83D\uDCA3 {culture} declara que o deus est\u00e1 morto \u2192 revolu\u00e7\u00f5es e guerras teol\u00f3gicas se iniciam.");
+        }
+    }
+}

--- a/src/UltraWorldAI/Interface/DivineInterface.cs
+++ b/src/UltraWorldAI/Interface/DivineInterface.cs
@@ -1,0 +1,27 @@
+using System;
+using UltraWorldAI.DivineWorld;
+
+namespace UltraWorldAI.Interface;
+
+public class DivineInterface
+{
+    public string SelectedActionType { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public void ShowMenu()
+    {
+        Console.WriteLine("\uD83C\uDF9C\uFE0F MODO DEUS \u2013 ESCOLHA SUA A\u00C7\u00C3O:");
+        Console.WriteLine("1. Milagre");
+        Console.WriteLine("2. Cat\u00e1strofe");
+        Console.WriteLine("3. Revela\u00e7\u00e3o");
+        Console.WriteLine("4. Criar entidade ou plano");
+        Console.WriteLine("5. Moldar territ\u00f3rio");
+    }
+
+    public void ConfirmAction()
+    {
+        DivineWillSystem.Intervene(Target, SelectedActionType, Description);
+        Console.WriteLine($"\u2705 A\u00e7\u00e3o divina enviada: {SelectedActionType} \u2192 {Target}");
+    }
+}

--- a/src/UltraWorldAI/Religion/ProphetAI.cs
+++ b/src/UltraWorldAI/Religion/ProphetAI.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace UltraWorldAI.Religion;
+
+public class ProphetAI
+{
+    public string Name { get; set; } = string.Empty;
+    public string Culture { get; set; } = string.Empty;
+    public float FaithLevel { get; set; }
+    public float MadnessLevel { get; set; }
+
+    public void InterpretDivineWill()
+    {
+        var rng = new Random();
+        var insight = FaithLevel - MadnessLevel + (float)rng.NextDouble() * 0.3f;
+
+        if (insight > 0.8f)
+        {
+            Console.WriteLine($"\uD83D\uDD2E {Name} recebe vis\u00e3o clara: 'O deus deseja paz e reclus\u00e3o.'");
+        }
+        else if (insight > 0.5f)
+        {
+            Console.WriteLine($"\uD83C\uDF00 {Name} interpreta: 'Devemos sacrificar artistas... talvez isso agrade a divindade.'");
+        }
+        else
+        {
+            Console.WriteLine($"\uD83D\uDD25 {Name} entra em del\u00edrio: 'A voz do deus me disse para incendiar o oceano e beber a fuma\u00e7a.'");
+        }
+    }
+}

--- a/tests/UltraWorldAI.Tests/DivineInterfaceTests.cs
+++ b/tests/UltraWorldAI.Tests/DivineInterfaceTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using UltraWorldAI.DivineWorld;
+using UltraWorldAI.Interface;
+using Xunit;
+
+public class DivineInterfaceTests
+{
+    [Fact]
+    public void ConfirmActionInvokesDivineWillSystem()
+    {
+        DivineWillSystem.Interventions.Clear();
+        var di = new DivineInterface
+        {
+            SelectedActionType = "Milagre",
+            Target = "Povoado",
+            Description = "Chuva de cura"
+        };
+
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        di.ConfirmAction();
+        Console.SetOut(original);
+
+        Assert.Single(DivineWillSystem.Interventions);
+        Assert.Contains("A\u00e7\u00e3o divina enviada", writer.ToString());
+    }
+}

--- a/tests/UltraWorldAI.Tests/DivineReactionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/DivineReactionSystemTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using UltraWorldAI.DivineWorld;
+using Xunit;
+
+public class DivineReactionSystemTests
+{
+    [Fact]
+    public void ReactToSilenceOutputsMessage()
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        DivineReactionSystem.ReactToSilence("TestCulture");
+        Console.SetOut(original);
+        Assert.NotEmpty(writer.ToString());
+    }
+}

--- a/tests/UltraWorldAI.Tests/ProphetAITests.cs
+++ b/tests/UltraWorldAI.Tests/ProphetAITests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class ProphetAITests
+{
+    [Fact]
+    public void InterpretDivineWillOutputsVision()
+    {
+        var prophet = new ProphetAI
+        {
+            Name = "Lior",
+            Culture = "Sarith",
+            FaithLevel = 1f,
+            MadnessLevel = 0f
+        };
+
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        prophet.InterpretDivineWill();
+        Console.SetOut(original);
+        Assert.Contains("Lior", writer.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DivineInterface` for player-driven divine actions
- implement `DivineReactionSystem` and `ProphetAI` to model cultures reacting to silence and prophets interpreting
- cover new modules with tests

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6844c1db25e48323ba5f643ec6a30139