### PR TITLE
Add religious conflict integration

### DIFF
--- a/src/UltraWorldAI/Religion/ReligiousConflictSystem.cs
+++ b/src/UltraWorldAI/Religion/ReligiousConflictSystem.cs
@@ -1,0 +1,35 @@
+using System;
+using UltraWorldAI.Politics;
+
+namespace UltraWorldAI.Religion;
+
+public static class ReligiousConflictSystem
+{
+    public static void ProclaimProphecy(string religionName, string title, string trigger, string prediction)
+    {
+        var religion = ReligionSystem.Religions.Find(r => r.Name == religionName);
+        if (religion == null) return;
+
+        ProphecySystem.Create(title, religionName, "sacerdotes", trigger, prediction);
+        HistorySystem.LogEvent($"{religionName} proclamou a profecia '{title}'");
+    }
+
+    public static void TriggerSchism(string doctrineTitle, string founderId, string reason)
+    {
+        var doctrine = DoctrineEngine.Doctrines.Find(d => d.Title == doctrineTitle);
+        if (doctrine == null) return;
+
+        var cult = CultSplit.CreateCultFromDoctrine(doctrine, founderId, reason);
+        HistorySystem.LogEvent($"{founderId} fundou o culto {cult.Name}");
+    }
+
+    public static void StartHolyWar(string religionName, string region)
+    {
+        var religion = ReligionSystem.Religions.Find(r => r.Name == religionName);
+        if (religion == null) return;
+
+        var cause = $"Guerra santa de {religionName} em {region}";
+        HouseWarSystem.DeclareWar(religionName, region, cause);
+        HistorySystem.LogEvent(cause);
+    }
+}

--- a/tests/UltraWorldAI.Tests/ReligiousConflictSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ReligiousConflictSystemTests.cs
@@ -1,0 +1,50 @@
+using UltraWorldAI;
+using UltraWorldAI.Politics;
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class ReligiousConflictSystemTests
+{
+    [Fact]
+    public void ProclaimProphecyAddsProphecyAndLogsEvent()
+    {
+        ReligionSystem.Religions.Clear();
+        HistorySystem.Events.Clear();
+        var religion = ReligionSystem.FoundReligion("Solaris", "Luz eterna", "Sul");
+        var before = ProphecySystem.AllProphecies.Count;
+
+        ReligiousConflictSystem.ProclaimProphecy(religion.Name, "Ascensao", "eclipse", "nova era");
+
+        Assert.Equal(before + 1, ProphecySystem.AllProphecies.Count);
+        Assert.Contains(HistorySystem.Events, e => e.EventName.Contains("proclamou a profecia"));
+    }
+
+    [Fact]
+    public void TriggerSchismCreatesCultAndLogs()
+    {
+        CultSplit.AllCults.Clear();
+        DoctrineEngine.Doctrines.Clear();
+        HistorySystem.Events.Clear();
+        var god = GodFactory.CreateGod("Zaros", DivineDomain.Luz, DivineTemperament.Benevolente);
+        var doctrine = DoctrineEngine.CreateDoctrine(god);
+
+        ReligiousConflictSystem.TriggerSchism(doctrine.Title, "Cyrus", "discordancia");
+
+        Assert.Single(CultSplit.AllCults);
+        Assert.Contains(HistorySystem.Events, e => e.EventName.Contains("fundou o culto"));
+    }
+
+    [Fact]
+    public void StartHolyWarCreatesWarAndLogs()
+    {
+        ReligionSystem.Religions.Clear();
+        HouseWarSystem.Wars.Clear();
+        HistorySystem.Events.Clear();
+        var religion = ReligionSystem.FoundReligion("Lunaris", "Sombra", "Norte");
+
+        ReligiousConflictSystem.StartHolyWar(religion.Name, "Norte");
+
+        Assert.Single(HouseWarSystem.Wars);
+        Assert.Contains(HistorySystem.Events, e => e.EventName.Contains("Guerra santa"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ReligiousConflictSystem` to tie religion modules together
- create unit tests for prophecy, schism, and holy war generation

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6844d012a75c83238190676b054898b7