### PR TITLE
Add prophet evolution and faith systems

### DIFF
--- a/src/UltraWorldAI/Religion/PilgrimageSystem.cs
+++ b/src/UltraWorldAI/Religion/PilgrimageSystem.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public class SacredArtifact
+{
+    public string Name { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public bool IsTechHeresy { get; set; }
+}
+
+public static class PilgrimageSystem
+{
+    public static List<SacredArtifact> Artifacts { get; } = new();
+    public static List<string> PilgrimageSites { get; } = new();
+
+    public static SacredArtifact AddArtifact(string name, string location, bool techHeresy = false)
+    {
+        var artifact = new SacredArtifact { Name = name, Location = location, IsTechHeresy = techHeresy };
+        Artifacts.Add(artifact);
+        return artifact;
+    }
+
+    public static void RegisterSite(string name)
+    {
+        if (!PilgrimageSites.Contains(name)) PilgrimageSites.Add(name);
+    }
+}
+

--- a/src/UltraWorldAI/Religion/ProphetEvolutionSystem.cs
+++ b/src/UltraWorldAI/Religion/ProphetEvolutionSystem.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public enum ProphetStage
+{
+    Prophet,
+    Martyr,
+    Saint
+}
+
+public class ProphetRecord
+{
+    public string Name { get; set; } = string.Empty;
+    public ProphetStage Stage { get; set; } = ProphetStage.Prophet;
+    public float Reverence { get; set; }
+}
+
+public static class ProphetEvolutionSystem
+{
+    private static readonly Dictionary<string, ProphetRecord> _records = new();
+
+    public static ProphetRecord Register(string name)
+    {
+        var record = new ProphetRecord { Name = name };
+        _records[name] = record;
+        return record;
+    }
+
+    public static void RecordMartyrdom(string name)
+    {
+        if (!_records.TryGetValue(name, out var record))
+        {
+            record = Register(name);
+        }
+
+        record.Stage = ProphetStage.Martyr;
+        record.Reverence = Math.Max(record.Reverence, 0.5f);
+        Console.WriteLine($"\uD83D\uDD4A️ {name} tornou-se m\u00e1rtir.");
+    }
+
+    public static void AddReverence(string name, float amount)
+    {
+        if (_records.TryGetValue(name, out var record))
+        {
+            record.Reverence = Math.Clamp(record.Reverence + amount, 0f, 1f);
+            if (record.Stage == ProphetStage.Martyr && record.Reverence >= 0.8f)
+            {
+                record.Stage = ProphetStage.Saint;
+                Console.WriteLine($"\u2728 {name} foi canonizado.");
+            }
+        }
+    }
+
+    public static ProphetStage? GetStage(string name)
+    {
+        return _records.TryGetValue(name, out var record) ? record.Stage : null;
+    }
+}
+

--- a/src/UltraWorldAI/Religion/ReactiveFaithSystem.cs
+++ b/src/UltraWorldAI/Religion/ReactiveFaithSystem.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace UltraWorldAI.Religion;
+
+public static class ReactiveFaithSystem
+{
+    private static readonly Dictionary<string, int> _miracleCounts = new();
+    private static readonly Dictionary<string, float> _fanaticism = new();
+
+    public static void RecordMiracle(string culture)
+    {
+        if (!_miracleCounts.ContainsKey(culture))
+            _miracleCounts[culture] = 0;
+        _miracleCounts[culture]++;
+        Adjust(culture);
+    }
+
+    private static void Adjust(string culture)
+    {
+        var count = _miracleCounts[culture];
+        var level = Math.Clamp(0.5f + count * 0.1f, 0f, 1f);
+        _fanaticism[culture] = level;
+    }
+
+    public static float GetFanaticism(string culture)
+    {
+        return _fanaticism.TryGetValue(culture, out var level) ? level : 0.5f;
+    }
+}
+

--- a/tests/UltraWorldAI.Tests/PilgrimageSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/PilgrimageSystemTests.cs
@@ -1,0 +1,18 @@
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class PilgrimageSystemTests
+{
+    [Fact]
+    public void AddArtifactRegistersArtifactAndSite()
+    {
+        PilgrimageSystem.Artifacts.Clear();
+        PilgrimageSystem.PilgrimageSites.Clear();
+        var artifact = PilgrimageSystem.AddArtifact("Olho Divino", "Monte", true);
+        PilgrimageSystem.RegisterSite("Monte");
+
+        Assert.Single(PilgrimageSystem.Artifacts);
+        Assert.Contains("Monte", PilgrimageSystem.PilgrimageSites);
+        Assert.True(artifact.IsTechHeresy);
+    }
+}

--- a/tests/UltraWorldAI.Tests/ProphetEvolutionSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ProphetEvolutionSystemTests.cs
@@ -1,0 +1,16 @@
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class ProphetEvolutionSystemTests
+{
+    [Fact]
+    public void MartyrdomAndCanonizationProgressesStage()
+    {
+        var record = ProphetEvolutionSystem.Register("Aro");
+        ProphetEvolutionSystem.RecordMartyrdom("Aro");
+        ProphetEvolutionSystem.AddReverence("Aro", 0.4f);
+
+        Assert.Equal(ProphetStage.Saint, ProphetEvolutionSystem.GetStage("Aro"));
+        Assert.True(record.Reverence >= 0.8f);
+    }
+}

--- a/tests/UltraWorldAI.Tests/ReactiveFaithSystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ReactiveFaithSystemTests.cs
@@ -1,0 +1,16 @@
+using UltraWorldAI.Religion;
+using Xunit;
+
+public class ReactiveFaithSystemTests
+{
+    [Fact]
+    public void RecordingMiraclesIncreasesFanaticism()
+    {
+        ReactiveFaithSystem.RecordMiracle("Mara");
+        ReactiveFaithSystem.RecordMiracle("Mara");
+
+        var level = ReactiveFaithSystem.GetFanaticism("Mara");
+
+        Assert.True(level > 0.6f);
+    }
+}


### PR DESCRIPTION
## Summary
- add prophet evolution system for martyr-to-saint progression
- add pilgrimage tracking for sacred artifacts
- add reactive faith system linking miracles to fanaticism
- test new religion systems

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6844d1d7c99c83238826eb000543d0c5