### PR TITLE
Add complexity system

### DIFF
--- a/src/UltraWorldAI/ComplexitySystem.cs
+++ b/src/UltraWorldAI/ComplexitySystem.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+
+namespace UltraWorldAI
+{
+    /// <summary>
+    /// Evaluates a simple complexity score for the current mental state.
+    /// </summary>
+    public class ComplexitySystem
+    {
+        public float ComplexityScore { get; private set; }
+
+        /// <summary>
+        /// Updates the <see cref="ComplexityScore"/> based on memory count,
+        /// average emotion intensity and number of beliefs.
+        /// </summary>
+        public void Update(Mind mind)
+        {
+            float memoryFactor = mind.Memory.Memories.Count / (float)AISettings.MaxMemories;
+            float emotionFactor = mind.Emotions.Emotions.Any()
+                ? mind.Emotions.Emotions.Values.Select(Math.Abs).Average()
+                : 0f;
+            float beliefFactor = mind.Beliefs.Beliefs.Count / 10f;
+
+            ComplexityScore = Math.Clamp((memoryFactor + emotionFactor + beliefFactor) / 3f, 0f, 1f);
+        }
+    }
+}

--- a/src/UltraWorldAI/Mind.cs
+++ b/src/UltraWorldAI/Mind.cs
@@ -49,6 +49,7 @@ namespace UltraWorldAI
         public Thoughts.EthicalJudgment Ethics { get; private set; }
         public Thoughts.LifeNarrative LifeNarrative { get; private set; }
         public Thoughts.HistoricalIdentity History { get; private set; }
+        public ComplexitySystem Complexity { get; private set; }
 
         public FrameworkSystem Framework { get; private set; }
 
@@ -100,6 +101,7 @@ namespace UltraWorldAI
             HabitatMemory = new Territory.HabitatMemory();
             Framework = new FrameworkSystem(person);
             LanguageLearner = new Language.NeuralLanguageLearner();
+            Complexity = new ComplexitySystem();
         }
 
         /// <summary>
@@ -113,6 +115,7 @@ namespace UltraWorldAI
             HandleIdeas();
             HandleDefenses();
             UpdateCultureSystems();
+            Complexity.Update(this);
         }
 
         private void UpdateDecaySystems()

--- a/tests/UltraWorldAI.Tests/ComplexitySystemTests.cs
+++ b/tests/UltraWorldAI.Tests/ComplexitySystemTests.cs
@@ -1,0 +1,30 @@
+using UltraWorldAI;
+using Xunit;
+
+public class ComplexitySystemTests
+{
+    [Fact]
+    public void ComplexityScoreUpdatesBasedOnState()
+    {
+        var person = new Person("Complex");
+        person.AddExperience("evento", 0.8f, 0.7f);
+        person.Mind.Beliefs.UpdateBelief("Nova crença", 0.6f);
+        person.Mind.Complexity.Update(person.Mind);
+
+        Assert.InRange(person.Mind.Complexity.ComplexityScore, 0.1f, 1f);
+    }
+
+    [Fact]
+    public void ComplexityScoreStaysWithinBounds()
+    {
+        var person = new Person("Bounds");
+        for (int i = 0; i < 200; i++)
+        {
+            person.AddExperience($"exp{i}", 1f, 1f);
+            person.Mind.Beliefs.UpdateBelief($"crenca{i}", 1f);
+        }
+        person.Mind.Complexity.Update(person.Mind);
+
+        Assert.InRange(person.Mind.Complexity.ComplexityScore, 0f, 1f);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ComplexitySystem` for computing a complexity score
- integrate it into `Mind` so the score updates every cycle
- test the new system

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build` *(fails: RealTimeStatsServerTests.ServerReturnsMapData)*

------
https://chatgpt.com/codex/tasks/task_e_6844dc6040a4832382516245657cf5ea