### PR TITLE
Add proprietary license and mention in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+UltraWorld - Proprietary License
+
+Copyright (c) 2024 Tiago Gontijo Ladeira
+
+All rights reserved.
+
+This software and its source code are the exclusive property of Tiago Gontijo Ladeira ("the Owner").
+
+Freelancers may collaborate on UltraWorld only with prior written authorization from the Owner.
+
+You are NOT permitted to:
+- Copy or redistribute the code or any portion of it
+- Modify or adapt the code for personal or commercial use
+- Reuse the code in any form without prior written permission
+- Sell or license any derivative works
+- Upload or publish any portion of this codebase elsewhere
+
+Any use of this code or its contents without explicit authorization is strictly prohibited and may result in legal action.
+
+For permissions or inquiries, contact: tiagogontijoladeira@gmail.com

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/example/UltraWorldCodes/actions/workflows/dotnet.yml/badge.svg)](https://github.com/example/UltraWorldCodes/actions)
 [![Coverage Status](https://img.shields.io/badge/coverage-auto-brightgreen)](docs/code_quality_metrics.md)
 [![Maintainability](https://img.shields.io/badge/maintainability-A-brightgreen)](docs/code_quality_metrics.md)
+[![License: Proprietary](https://img.shields.io/badge/license-Proprietary-lightgrey)](LICENSE)
 
 This repository contains the game code and the AI module. The AI logic is
 split across several files under `src/UltraWorldAI/`, each implementing
@@ -218,6 +219,10 @@ Contributions are welcome! A full guide is available in [CONTRIBUTING.md](CONTRI
 - Add or update unit tests whenever you introduce new functionality.
 - Document any public APIs you create or modify in the `docs` folder.
 - Prefer the built-in `Logger` and use its asynchronous methods when logging to disk.
+
+## License
+
+UltraWorldCodes is distributed under a proprietary license. See [LICENSE](LICENSE) for full terms. Collaboration on the code is permitted only with prior written authorization from the owner.
 
 ## Performance Hints
 


### PR DESCRIPTION
## Summary
- add proprietary license text with clause for freelancers
- show a new license badge in the README
- mention the proprietary license in README

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6845613934ac8323abdfe058c8aa1580