### PR TITLE
Add Unity export helper

### DIFF
--- a/docs/unity_integration.md
+++ b/docs/unity_integration.md
@@ -11,3 +11,14 @@ This project targets .NET 8 and can be imported into Unity as a managed plugin. 
 4. Ensure your Unity project is set to use the `Mono` scripting backend or a version of `IL2CPP` that supports .NET 8 assemblies.
 
 Because the project uses modern .NET features, older versions of Unity may not load the DLL. Unity 2022.3 and newer is recommended.
+
+### Copying Source Code Without Building
+
+If you prefer to have Unity compile the library directly, run:
+
+```bash
+tools/export-to-unity.sh /path/to/your/UnityProject/Assets/UltraWorldAI
+```
+
+This script copies all source files under `src/UltraWorldAI` to the specified
+destination. Unity will compile these scripts on the next refresh.

--- a/tools/export-to-unity.sh
+++ b/tools/export-to-unity.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Copies the UltraWorldAI source code into a Unity project so Unity can compile it.
+# Usage: tools/export-to-unity.sh [destination]
+
+set -e
+
+dest=${1:-Unity/Source}
+
+mkdir -p "$dest"
+# Synchronize source code while removing files no longer present in src
+rsync -a --delete src/UltraWorldAI/ "$dest/"
+
+echo "Source code exported to $dest"


### PR DESCRIPTION
## Summary
- add `export-to-unity.sh` script to copy source for Unity compilation
- document how to use the script in `docs/unity_integration.md`

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463848a3488323bd90799088079c6d