### PR TITLE
Fix build errors and ensure serialization uses system JsonInclude

### DIFF
--- a/src/UltraWorldAI/UltraWorldAI.csproj
+++ b/src/UltraWorldAI/UltraWorldAI.csproj
@@ -7,7 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Mono.Data.Sqlite" Version="1.0.0" />
     <!-- Removed Microsoft.Data.Sqlite, Microsoft.Extensions.Logging and System.Text.Json -->
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../UnityEngine/*.cs" />
   </ItemGroup>
 </Project>

--- a/src/UnityEngine/JsonIncludeAttribute.cs
+++ b/src/UnityEngine/JsonIncludeAttribute.cs
@@ -1,5 +1,0 @@
-namespace System.Text.Json.Serialization
-{
-    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
-    public sealed class JsonIncludeAttribute : System.Attribute { }
-}


### PR DESCRIPTION
## Summary
- include UnityEngine stub files in library project
- add Mono.Data.Sqlite dependency for persistence
- remove custom `JsonIncludeAttribute`
- tests now pass

## Testing
- `dotnet build -c Release src/UltraWorldAI/UltraWorldAI.csproj`
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684737ccd4048323bc34e2b0994b3388