### PR TITLE
Rename Debug to AIDebug to avoid Unity conflict

### DIFF
--- a/src/UltraWorldAI/BaseTypes.cs
+++ b/src/UltraWorldAI/BaseTypes.cs
@@ -132,7 +132,7 @@ namespace UltraWorldAI
 
             if (StructuredLogger != null)
             {
-                Debug.Log(formatted);
+                AIDebug.Log(formatted);
             }
             else
             {
@@ -174,7 +174,7 @@ namespace UltraWorldAI
 
             if (StructuredLogger != null)
             {
-                Debug.Log(formatted);
+                AIDebug.Log(formatted);
             }
             else
             {

--- a/src/UnityEngine/AIDebug.cs
+++ b/src/UnityEngine/AIDebug.cs
@@ -1,6 +1,6 @@
 namespace UnityEngine
 {
-    public static class Debug
+    public static class AIDebug
     {
         public static void Log(object message) => System.Console.WriteLine(message);
     }


### PR DESCRIPTION
## Summary
- rename the local `Debug` helper to `AIDebug`
- refactor logging calls to use `AIDebug`

## Testing
- `dotnet test tests/UltraWorldAI.Tests/UltraWorldAI.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684743727ee48323aa71053e50ffae99